### PR TITLE
Enhance daily menu screen

### DIFF
--- a/src/components/FullMenuPanel.tsx
+++ b/src/components/FullMenuPanel.tsx
@@ -9,6 +9,11 @@ import {
   ScrollView,
   TouchableOpacity,
 } from 'react-native';
+import { MEALS } from '../data/meals';
+
+function formatTime(h: number, m: number) {
+  return `${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}`;
+}
 
 export default function FullMenuScreen({ onClose }: { onClose: () => void }) {
   return (
@@ -20,20 +25,15 @@ export default function FullMenuScreen({ onClose }: { onClose: () => void }) {
         <Text style={styles.title}>Full Day’s Menu</Text>
       </View>
       <ScrollView contentContainerStyle={styles.content}>
-        <Text style={styles.mealHeader}>Breakfast (08:00 – 10:00):</Text>
-        <Text style={styles.mealItems}>
-          Upma, Poha, Idli, Paratha, Aloo Bhaji, Chai
-        </Text>
-
-        <Text style={styles.mealHeader}>Lunch (12:30 – 14:00):</Text>
-        <Text style={styles.mealItems}>
-          Veg Biryani, Dal Makhani, Mixed Veg, Roti, Salad
-        </Text>
-
-        <Text style={styles.mealHeader}>Dinner (19:00 – 21:00):</Text>
-        <Text style={styles.mealItems}>
-          Paneer Butter Masala, Chapati, Dal Tadka, Rice, Raita
-        </Text>
+        {MEALS.map((meal) => (
+          <React.Fragment key={meal.name}>
+            <Text style={styles.mealHeader}>
+              {meal.name} ({formatTime(meal.startHour, meal.startMinute)} –
+              {formatTime(meal.endHour, meal.endMinute)}):
+            </Text>
+            <Text style={styles.mealItems}>{meal.items.join(', ')}</Text>
+          </React.Fragment>
+        ))}
       </ScrollView>
     </SafeAreaView>
   );

--- a/src/components/WhatsNextPanel.tsx
+++ b/src/components/WhatsNextPanel.tsx
@@ -18,37 +18,11 @@ import {
   Pressable,
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
+import { MEALS } from '../data/meals';
 
 const { height: SCREEN_HEIGHT } = Dimensions.get('window');
 const PANEL_HEIGHT = SCREEN_HEIGHT * 0.35; // covers 35% of screen
 
-/* ―― Demo meal data (unchanged) ―― */
-const MEALS = [
-  {
-    name: 'Breakfast',
-    startHour: 8,
-    startMinute: 0,
-    endHour: 10,
-    endMinute: 0,
-    items: ['Upma', 'Poha', 'Idli', 'Paratha', 'Aloo Bhaji', 'Chai'],
-  },
-  {
-    name: 'Lunch',
-    startHour: 12,
-    startMinute: 30,
-    endHour: 14,
-    endMinute: 0,
-    items: ['Veg Biryani', 'Dal Makhani', 'Mixed Veg', 'Roti', 'Salad'],
-  },
-  {
-    name: 'Dinner',
-    startHour: 19,
-    startMinute: 0,
-    endHour: 21,
-    endMinute: 0,
-    items: ['Paneer Butter Masala', 'Chapati', 'Dal Tadka', 'Rice', 'Raita'],
-  },
-];
 
 function formatHour(h: number, m: number): string {
   let suffix = 'AM';
@@ -218,7 +192,14 @@ const WhatsNextPanel = forwardRef<WhatsNextPanelHandle, Props>(
 
         <Pressable
           style={styles.fullMenuButton}
-          onPress={() => navigation.getParent()?.navigate('FoodMenuScreen')}
+          onPress={() => {
+            navigation.getParent()?.navigate('FoodMenu');
+            Animated.timing(slide, {
+              toValue: 0,
+              duration: 150,
+              useNativeDriver: true,
+            }).start(() => onDismiss());
+          }}
         >
           <Text style={styles.fullMenuText}>View Full Menu</Text>
         </Pressable>

--- a/src/data/meals.ts
+++ b/src/data/meals.ts
@@ -1,0 +1,48 @@
+export type Meal = {
+  name: string;
+  startHour: number;
+  startMinute: number;
+  endHour: number;
+  endMinute: number;
+  items: string[];
+  highlights?: string[]; // special dishes shown vertically
+};
+
+export const MEALS: Meal[] = [
+  {
+    name: 'Breakfast',
+    startHour: 8,
+    startMinute: 0,
+    endHour: 10,
+    endMinute: 0,
+    items: ['Upma', 'Poha', 'Idli', 'Paratha', 'Aloo Bhaji', 'Chai'],
+    highlights: ['Masala Dosa'],
+  },
+  {
+    name: 'Lunch',
+    startHour: 12,
+    startMinute: 30,
+    endHour: 14,
+    endMinute: 0,
+    items: ['Veg Biryani', 'Dal Makhani', 'Mixed Veg', 'Roti', 'Salad'],
+    highlights: ['Gulab Jamun'],
+  },
+  {
+    name: 'Snacks',
+    startHour: 16,
+    startMinute: 0,
+    endHour: 17,
+    endMinute: 0,
+    items: ['Tea', 'Coffee', 'Puffs', 'Cookies'],
+    highlights: ['Samosa'],
+  },
+  {
+    name: 'Dinner',
+    startHour: 19,
+    startMinute: 0,
+    endHour: 21,
+    endMinute: 0,
+    items: ['Paneer Butter Masala', 'Chapati', 'Dal Tadka', 'Rice', 'Raita'],
+    highlights: ['Ice Cream'],
+  },
+];

--- a/src/screens/FoodMenuScreen.tsx
+++ b/src/screens/FoodMenuScreen.tsx
@@ -1,6 +1,6 @@
 // src/screens/FoodMenuScreen.tsx
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   View,
   Text,
@@ -8,32 +8,138 @@ import {
   SafeAreaView,
   ScrollView,
   TouchableOpacity,
+  Animated,
 } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import RatingModal from '../components/RatingModal';
+import { MEALS } from '../data/meals';
+
+function formatTime(h: number, m: number) {
+  return `${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}`;
+}
+
+type Ratings = { [key: string]: number };
 
 export default function FoodMenuScreen({ navigation }: any) {
+  const today = new Date();
+  const dateLabel = today.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+  });
+
+  const [ratings, setRatings] = useState<Ratings>({});
+  const [timers, setTimers] = useState<{ [name: string]: string }>({});
+  const [statuses, setStatuses] = useState<{ [name: string]: 'ongoing' | 'next' | 'later' }>({});
+  const [modalItem, setModalItem] = useState<string | null>(null);
+
+  useEffect(() => {
+    AsyncStorage.getItem('mealRatings').then((raw) => {
+      if (raw) setRatings(JSON.parse(raw));
+    });
+  }, []);
+
+  useEffect(() => {
+    const updateTimers = () => {
+      const now = new Date();
+      let nextIdx = -1;
+      MEALS.forEach((m, idx) => {
+        const start = new Date();
+        start.setHours(m.startHour, m.startMinute, 0, 0);
+        if (start > now && nextIdx === -1) nextIdx = idx;
+      });
+      MEALS.forEach((m, idx) => {
+        const start = new Date();
+        const end = new Date();
+        start.setHours(m.startHour, m.startMinute, 0, 0);
+        end.setHours(m.endHour, m.endMinute, 0, 0);
+
+        let status: 'ongoing' | 'next' | 'later' = 'later';
+        if (now >= start && now < end) status = 'ongoing';
+        else if (idx === nextIdx) status = 'next';
+
+        const diff = start.getTime() - now.getTime();
+        const secs = Math.max(0, Math.floor(diff / 1000));
+        const hrs = Math.floor(secs / 3600);
+        const mins = Math.floor((secs % 3600) / 60);
+        const s = secs % 60;
+        const pad = (n: number) => (n < 10 ? `0${n}` : `${n}`);
+        const label = now >= start ? 'Started' : `${pad(hrs)}:${pad(mins)}:${pad(s)}`;
+
+        setTimers((t) => ({ ...t, [m.name]: label }));
+        setStatuses((s2) => ({ ...s2, [m.name]: status }));
+      });
+    };
+    updateTimers();
+    const id = setInterval(updateTimers, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const openModal = (itemKey: string) => setModalItem(itemKey);
+  const closeModal = () => setModalItem(null);
+  const submitRating = async (itemKey: string, rating: number) => {
+    const updated = { ...ratings, [itemKey]: rating };
+    setRatings(updated);
+    await AsyncStorage.setItem('mealRatings', JSON.stringify(updated));
+  };
+
   return (
     <SafeAreaView style={styles.root}>
       <View style={styles.header}>
         <TouchableOpacity onPress={() => navigation.goBack()}>
           <Text style={styles.backText}>← Back</Text>
         </TouchableOpacity>
-        <Text style={styles.title}>Full Day’s Menu</Text>
+        <View style={styles.headerTextWrap}>
+          <Text style={styles.title}>Full Day’s Menu</Text>
+          <Text style={styles.dateLabel}>{dateLabel}</Text>
+        </View>
       </View>
       <ScrollView contentContainerStyle={styles.content}>
-        <Text style={styles.mealHeader}>Breakfast (08:00 – 10:00):</Text>
-        <Text style={styles.mealItems}>
-          Upma, Poha, Idli, Paratha, Aloo Bhaji, Chai
-        </Text>
-
-        <Text style={styles.mealHeader}>Lunch (12:30 – 14:00):</Text>
-        <Text style={styles.mealItems}>
-          Veg Biryani, Dal Makhani, Mixed Veg, Roti, Salad
-        </Text>
-
-        <Text style={styles.mealHeader}>Dinner (19:00 – 21:00):</Text>
-        <Text style={styles.mealItems}>
-          Paneer Butter Masala, Chapati, Dal Tadka, Rice, Raita
-        </Text>
+        {MEALS.map((meal) => {
+          const timer = timers[meal.name] || '';
+          const status = statuses[meal.name];
+          return (
+            <Animated.View
+              key={meal.name}
+              style={[
+                styles.mealBlock,
+                status === 'ongoing' && styles.ongoing,
+                status === 'next' && styles.next,
+              ]}
+            >
+              <View style={styles.mealHeaderRow}>
+                <Text style={styles.mealHeader}>{meal.name}</Text>
+                <Text style={styles.timer}>{timer}</Text>
+              </View>
+              <Text style={styles.timeRange}>
+                {formatTime(meal.startHour, meal.startMinute)} – {formatTime(meal.endHour, meal.endMinute)}
+              </Text>
+              <Text style={styles.mealItems}>{meal.items.join(', ')}</Text>
+              {meal.highlights?.map((item) => {
+                const key = `${meal.name}-${item}`;
+                return (
+                  <View key={key} style={styles.highlightRow}>
+                    <Text style={styles.highlightText}>{item}</Text>
+                    <TouchableOpacity
+                      onPress={() => openModal(key)}
+                      style={styles.rateButton}
+                    >
+                      <Text style={styles.rateText}>{ratings[key] ? `${ratings[key]}★` : 'Rate'}</Text>
+                    </TouchableOpacity>
+                    {modalItem === key && (
+                      <RatingModal
+                        visible={true}
+                        onClose={closeModal}
+                        onSubmit={(r) => submitRating(key, r)}
+                        initialRating={ratings[key]}
+                      />
+                    )}
+                  </View>
+                );
+              })}
+            </Animated.View>
+          );
+        })}
       </ScrollView>
     </SafeAreaView>
   );
@@ -42,7 +148,7 @@ export default function FoodMenuScreen({ navigation }: any) {
 const styles = StyleSheet.create({
   root: {
     flex: 1,
-    backgroundColor: '#fff',
+    backgroundColor: '#faf8f2',
   },
   header: {
     flexDirection: 'row',
@@ -50,6 +156,10 @@ const styles = StyleSheet.create({
     padding: 16,
     borderBottomColor: '#ddd',
     borderBottomWidth: 1,
+  },
+  headerTextWrap: {
+    flex: 1,
+    alignItems: 'center',
   },
   backText: {
     fontSize: 16,
@@ -60,18 +170,66 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontWeight: '600',
   },
+  dateLabel: {
+    fontSize: 14,
+    color: '#666',
+  },
   content: {
     padding: 16,
+  },
+  mealBlock: {
+    backgroundColor: '#fff',
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 12,
+  },
+  ongoing: {
+    backgroundColor: '#e8f5e9',
+  },
+  next: {
+    backgroundColor: '#fff8e1',
+  },
+  mealHeaderRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
   },
   mealHeader: {
     fontSize: 16,
     fontWeight: '600',
-    marginTop: 12,
+  },
+  timer: {
+    fontSize: 12,
+    color: '#d9534f',
+  },
+  timeRange: {
+    fontSize: 12,
+    color: '#666',
     marginBottom: 4,
   },
   mealItems: {
     fontSize: 14,
     color: '#444',
     lineHeight: 20,
+  },
+  highlightRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 6,
+  },
+  highlightText: {
+    flex: 1,
+    fontSize: 14,
+    color: '#333',
+  },
+  rateButton: {
+    backgroundColor: '#007bff',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 6,
+  },
+  rateText: {
+    color: '#fff',
+    fontSize: 12,
   },
 });


### PR DESCRIPTION
## Summary
- add highlights and snacks data to meal schedule
- close "What's Next" panel when opening full menu
- implement timers and rating buttons for menu items
- style full day menu screen with date and status indicators

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: Cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684831d20ee8832fbd88f91fecd43651