### PR TITLE
Fix food menu utilities

### DIFF
--- a/src/components/WhatsNextPanel.tsx
+++ b/src/components/WhatsNextPanel.tsx
@@ -19,6 +19,7 @@ import {
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { MEALS } from '../data/meals';
+import type { Meal } from '../data/meals';
 
 const { height: SCREEN_HEIGHT } = Dimensions.get('window');
 const PANEL_HEIGHT = SCREEN_HEIGHT * 0.35; // covers 35% of screen
@@ -48,7 +49,7 @@ type Props = {
 };
 
 const WhatsNextPanel = forwardRef<WhatsNextPanelHandle, Props>(
-  ({ isVisible, onDismiss }, ref) => {
+  ({ isVisible, onDismiss }: Props, ref: React.ForwardedRef<WhatsNextPanelHandle>) => {
     const navigation = useNavigation();
 
     // Animated value: 0 = hidden above, 1 = fully visible
@@ -87,7 +88,7 @@ const WhatsNextPanel = forwardRef<WhatsNextPanelHandle, Props>(
     // Compute next meal
     function computeNextMeal(): Date {
       const now = new Date();
-      let found = MEALS.find((meal) => {
+      let found: Meal | undefined = MEALS.find((meal: Meal) => {
         if (now.getHours() < meal.startHour) return true;
         if (
           now.getHours() === meal.startHour &&

--- a/src/data/meals.ts
+++ b/src/data/meals.ts
@@ -51,3 +51,5 @@ export const MEALS: Meal[] = [
 
   },
 ];
+
+export default MEALS;

--- a/src/screens/FoodMenuScreen.tsx
+++ b/src/screens/FoodMenuScreen.tsx
@@ -15,8 +15,13 @@ import RatingModal from '../components/RatingModal';
 
 import { MEALS } from '../data/meals';
 
+// Pad numbers to two digits without relying on ES2017 String.padStart
+function pad(n: number): string {
+  return n < 10 ? `0${n}` : `${n}`;
+}
+
 function formatTime(h: number, m: number) {
-  return `${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}`;
+  return `${pad(h)}:${pad(m)}`;
 }
 
 type Ratings = { [key: string]: number };
@@ -141,16 +146,6 @@ export default function FoodMenuScreen({ navigation }: any) {
             </Animated.View>
           );
         })}
-        {MEALS.map((meal) => (
-          <React.Fragment key={meal.name}>
-            <Text style={styles.mealHeader}>
-              {meal.name} ({formatTime(meal.startHour, meal.startMinute)} –
-              {formatTime(meal.endHour, meal.endMinute)}):
-            </Text>
-            <Text style={styles.mealItems}>{meal.items.join(', ')}</Text>
-          </React.Fragment>
-        ))}
-
       </ScrollView>
     </SafeAreaView>
   );


### PR DESCRIPTION
## Summary
- add pad helper and remove duplicate mapping in food menu screen
- type improvements in WhatsNextPanel
- export default meals data

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc src/components/WhatsNextPanel.tsx src/data/meals.ts src/screens/FoodMenuScreen.tsx --jsx react --lib es2017,dom --skipLibCheck --noEmit` *(fails: cannot find module type declarations)*


------
https://chatgpt.com/codex/tasks/task_e_684839ffe790832fbc089938fd6041c7