### PR TITLE
Fix navigation error for FoodMenuScreen

### DIFF
--- a/src/components/WhatsNextPanel.tsx
+++ b/src/components/WhatsNextPanel.tsx
@@ -197,8 +197,6 @@ const WhatsNextPanel = forwardRef<WhatsNextPanelHandle, Props>(
 
             navigation.getParent()?.navigate('FoodMenuScreen');
 
-            navigation.getParent()?.navigate('FoodMenu');
-
             Animated.timing(slide, {
               toValue: 0,
               duration: 150,


### PR DESCRIPTION
## Summary
- ensure `WhatsNextPanel` only navigates to `FoodMenuScreen`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68483b451560832fbc914dd7429866d3