### PR TITLE
Fix header colliding with system status bar

### DIFF
--- a/src/screens/FoodMenuScreen.tsx
+++ b/src/screens/FoodMenuScreen.tsx
@@ -5,11 +5,13 @@ import {
   View,
   Text,
   StyleSheet,
-  SafeAreaView,
   ScrollView,
   TouchableOpacity,
   Animated,
+  StatusBar,
+  Platform,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import RatingModal from '../components/RatingModal';
 
@@ -155,6 +157,7 @@ const styles = StyleSheet.create({
   root: {
     flex: 1,
     backgroundColor: '#faf8f2',
+    paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0,
   },
   header: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary
- use SafeAreaView from safe-area-context
- apply top padding on Android

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: Cannot find module 'react', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68483c32dc14832f9797accc20ba1921