### PR TITLE
Fix duplicate key warning in Gallery

### DIFF
--- a/src/screens/GalleryScreen.tsx
+++ b/src/screens/GalleryScreen.tsx
@@ -73,7 +73,7 @@ export default function GalleryScreen() {
           selectedValue={selectedClass}
           onValueChange={(val) => setSelectedClass(val)}
         >
-          <Picker.Item label="All Classes" value="all" />
+          <Picker.Item key="all" label="All Classes" value="all" />
           {classIds.map((cid) => (
             <Picker.Item key={cid} label={`Class ${cid}`} value={cid} />
           ))}
@@ -87,7 +87,7 @@ export default function GalleryScreen() {
       ) : (
         <FlatList
           data={flatData}
-          keyExtractor={(item, idx) => item.uri + idx}
+          keyExtractor={(item) => `${item.timestamp}-${item.uri}`}
           numColumns={3}
           renderItem={({ item }) => (
             <Image source={{ uri: item.uri }} style={styles.photo} />


### PR DESCRIPTION
## Summary
- ensure `<Picker>` has a key for `All Classes`
- generate unique keys for gallery photos

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68483cb238f4832fb25f12b370e1dc81