### PR TITLE
Use custom camera for quick capture

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "expo-image-picker": "~16.1.4",
         "expo-linear-gradient": "~14.1.5",
         "expo-location": "~18.1.5",
+        "expo-media-library": "~17.1.7",
         "expo-navigation-bar": "~4.2.5",
         "expo-sensors": "~14.1.4",
         "expo-status-bar": "~2.2.3",
@@ -5777,6 +5778,16 @@
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-media-library": {
+      "version": "17.1.7",
+      "resolved": "https://registry.npmjs.org/expo-media-library/-/expo-media-library-17.1.7.tgz",
+      "integrity": "sha512-hLCoMvlhjtt+iYxPe71P1F6t06mYGysuNOfjQzDbbf64PCkglCZJYmywPyUSV1V5Hu9DhRj//gEg+Ki+7VWXog==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {

--- a/package.json
+++ b/package.json
@@ -27,11 +27,13 @@
     "expo-image-picker": "~16.1.4",
     "expo-linear-gradient": "~14.1.5",
     "expo-location": "~18.1.5",
+    "expo-media-library": "~17.1.7",
     "expo-navigation-bar": "~4.2.5",
     "expo-sensors": "~14.1.4",
     "expo-status-bar": "~2.2.3",
     "react": "19.0.0",
     "react-dom": "19.0.0",
+    "react-native": "0.79.3",
     "react-native-color-picker": "^0.6.0",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-linear-gradient": "^2.8.3",
@@ -42,8 +44,7 @@
     "react-native-skottie": "^2.1.4",
     "react-native-svg": "^15.11.2",
     "react-native-web": "^0.20.0",
-    "react-native-wheel-color-picker": "^1.3.1",
-    "react-native": "0.79.3"
+    "react-native-wheel-color-picker": "^1.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/components/CameraModal.tsx
+++ b/src/components/CameraModal.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Modal, View, TouchableOpacity, StyleSheet, Text } from 'react-native';
+import { Camera, CameraType } from 'expo-camera';
+import * as MediaLibrary from 'expo-media-library';
+
+export type CameraModalProps = {
+  visible: boolean;
+  onClose: () => void;
+  onCapture: (uri: string) => void;
+};
+
+export default function CameraModal({ visible, onClose, onCapture }: CameraModalProps) {
+  const cameraRef = useRef<Camera | null>(null);
+  const [hasPermission, setHasPermission] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      const { status } = await Camera.requestCameraPermissionsAsync();
+      const { status: mediaStatus } = await MediaLibrary.requestPermissionsAsync();
+      setHasPermission(status === 'granted' && mediaStatus === 'granted');
+    })();
+  }, []);
+
+  const handleShoot = async () => {
+    if (cameraRef.current) {
+      const photo = await cameraRef.current.takePictureAsync();
+      const asset = await MediaLibrary.createAssetAsync(photo.uri);
+      onCapture(asset.uri);
+      onClose();
+    }
+  };
+
+  if (!visible) return null;
+
+  return (
+    <Modal visible={visible} animationType="slide">
+      <View style={styles.container}>
+        {hasPermission && (
+          <Camera
+            ref={cameraRef}
+            style={StyleSheet.absoluteFill}
+            type={CameraType.back}
+            autoFocus={Camera.Constants.AutoFocus.on}
+          />
+        )}
+        <View style={styles.bottomBar}>
+          <TouchableOpacity style={styles.captureButton} onPress={handleShoot} />
+          <TouchableOpacity style={styles.close} onPress={onClose}>
+            <Text style={styles.closeText}>Close</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#000' },
+  bottomBar: {
+    position: 'absolute',
+    bottom: 40,
+    width: '100%',
+    alignItems: 'center',
+  },
+  captureButton: {
+    width: 70,
+    height: 70,
+    borderRadius: 35,
+    borderWidth: 4,
+    borderColor: '#fff',
+  },
+  close: {
+    position: 'absolute',
+    top: 40,
+    left: 20,
+  },
+  closeText: {
+    color: '#fff',
+    fontSize: 18,
+  },
+});

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -14,7 +14,7 @@ import {
 import { LinearGradient } from 'expo-linear-gradient';
 import Svg, { Path } from 'react-native-svg';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import * as ImagePicker from 'expo-image-picker';
+import CameraModal from './CameraModal';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import RatingModal from './RatingModal';
 import TemperatureBadge from './TemperatureBadge';
@@ -115,29 +115,17 @@ export default function Card({
   // Choose painterly gradient
   const gradientColors = GRADIENTS[index % GRADIENTS.length];
 
-  // Take photo
-  const takePhoto = async () => {
-    try {
-      const { status } = await ImagePicker.requestCameraPermissionsAsync();
-      if (status !== 'granted') return;
-      const result = await ImagePicker.launchCameraAsync({
-        quality: 0.5,
-        base64: false,
-      });
-      if (!result.cancelled) {
-        const uri = result.uri;
-        const timestamp = Date.now();
-        const raw = await AsyncStorage.getItem('photosByClass');
-        const parsed: { [key: string]: { uri: string; timestamp: number }[] } =
-          raw ? JSON.parse(raw) : {};
-        const arr = parsed[classId] || [];
-        arr.push({ uri, timestamp });
-        parsed[classId] = arr;
-        await AsyncStorage.setItem('photosByClass', JSON.stringify(parsed));
-      }
-    } catch {
-      // silent
-    }
+  const [cameraVisible, setCameraVisible] = useState(false);
+
+  const handleCapture = async (uri: string) => {
+    const timestamp = Date.now();
+    const raw = await AsyncStorage.getItem('photosByClass');
+    const parsed: { [key: string]: { uri: string; timestamp: number }[] } =
+      raw ? JSON.parse(raw) : {};
+    const arr = parsed[classId] || [];
+    arr.push({ uri, timestamp });
+    parsed[classId] = arr;
+    await AsyncStorage.setItem('photosByClass', JSON.stringify(parsed));
   };
 
   // Submit rating
@@ -214,7 +202,7 @@ export default function Card({
             <View style={styles.buttonBar}>
               <TouchableOpacity
                 style={styles.button}
-                onPress={takePhoto}
+                onPress={() => setCameraVisible(true)}
                 activeOpacity={0.7}
               >
                 <Ionicons name="camera" size={20} color="#fff" />
@@ -280,6 +268,11 @@ export default function Card({
         onClose={() => setShowRatingModal(false)}
         onSubmit={submitRating}
         initialRating={currentRating}
+      />
+      <CameraModal
+        visible={cameraVisible}
+        onClose={() => setCameraVisible(false)}
+        onCapture={handleCapture}
       />
     </View>
   );


### PR DESCRIPTION
## Summary
- add `expo-media-library` for saving photos to gallery
- create `CameraModal` component using `expo-camera`
- store captured photos directly and remove confirmation
- use new camera modal from `Card`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68483e8d883c832f9e245df9fe1054a6