### PR TITLE
Fix camera capture crash

### DIFF
--- a/app.json
+++ b/app.json
@@ -19,7 +19,7 @@
       "backgroundColor": "#121212",    // dark shade behind Home/Recents/Back
       "barStyle": "light-content"      // makes the system icons white
     },
-    "plugins": ["expo-media-library"],
+    "plugins": ["expo-media-library", "expo-camera"],
 
     "ios": {
       "supportsTablet": true,
@@ -36,7 +36,8 @@
       // "edgeToEdgeEnabled": true,
       "package": "com.anonymous.vitstudentapp",
       "permissions": [
-        "ACCESS_FINE_LOCATION"
+        "ACCESS_FINE_LOCATION",
+        "CAMERA"
       ]
     },
     "web": {

--- a/src/components/CameraModal.tsx
+++ b/src/components/CameraModal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Modal, View, TouchableOpacity, StyleSheet, Text } from 'react-native';
-import { Camera, CameraType } from 'expo-camera';
+import { Camera } from 'expo-camera';
 import * as MediaLibrary from 'expo-media-library';
 
 export type CameraModalProps = {
@@ -39,7 +39,7 @@ export default function CameraModal({ visible, onClose, onCapture }: CameraModal
           <Camera
             ref={cameraRef}
             style={StyleSheet.absoluteFill}
-            type={CameraType.back}
+            type={Camera.Constants.Type.back}
             autoFocus={Camera.Constants.AutoFocus.on}
           />
         )}


### PR DESCRIPTION
## Summary
- use `Camera.Constants.Type.back` to avoid undefined export
- add expo-camera plugin and camera permission

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684842229114832fb9edcb435792236a