### PR TITLE
Fix Today's Menu layout

### DIFF
--- a/src/components/SummaryCard.tsx
+++ b/src/components/SummaryCard.tsx
@@ -380,7 +380,8 @@ const styles = StyleSheet.create({
 
   menuGrid: { flexDirection:'row', flexWrap:'wrap', justifyContent:'space-between' },
   menuBox:  {
-    width:(width - 16*3)/2,
+    // use percentage width for more flexible two-column layout
+    width: '48%',
     backgroundColor:'#fff',
     borderRadius:12,
     padding:12,

--- a/src/screens/FoodMenuScreen.tsx
+++ b/src/screens/FoodMenuScreen.tsx
@@ -244,7 +244,8 @@ const styles = StyleSheet.create({
     padding: 12,
     marginVertical: 8,
     marginHorizontal: 4,
-    width: (width - 16 * 3) / 2,
+    // use a percentage width to display two columns on most screens
+    width: '48%',
   },
   ongoing: {
     backgroundColor: '#e8f5e9',


### PR DESCRIPTION
## Summary
- improve Today's Menu grid to show two columns
- ensure Food Menu screen uses same two-column grid

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684843bd18fc832f867e4198bf8446f6