### PR TITLE
Add working profile screen with icon picker

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -39,10 +39,13 @@ function SocialScreen() {
 // Import those here:
 import MoreRootScreen from './src/screens/MoreRootScreen';
 import GalleryScreen from './src/screens/GalleryScreen';
+import Profile from './src/screens/Profile';
+import { UserProvider } from './src/context/UserContext';
 
 type RootStackParamList = {
   MainTabs: undefined;
   FoodMenuScreen: undefined;
+  Profile: undefined;
 };
 
 type TabParamList = {
@@ -118,15 +121,18 @@ function MainTabs() {
 export default function App() {
   return (
     <SafeAreaProvider>
-      <NavigationContainer>
-        <RootStack.Navigator screenOptions={{ headerShown: false }}>
-          <RootStack.Screen name="MainTabs" component={MainTabs} />
-          <RootStack.Screen
-            name="FoodMenuScreen"
-            component={FoodMenuScreen}
-          />
-        </RootStack.Navigator>
-      </NavigationContainer>
+      <UserProvider>
+        <NavigationContainer>
+          <RootStack.Navigator screenOptions={{ headerShown: false }}>
+            <RootStack.Screen name="MainTabs" component={MainTabs} />
+            <RootStack.Screen
+              name="FoodMenuScreen"
+              component={FoodMenuScreen}
+            />
+            <RootStack.Screen name="Profile" component={Profile} />
+          </RootStack.Navigator>
+        </NavigationContainer>
+      </UserProvider>
     </SafeAreaProvider>
   );
 }

--- a/src/components/SummaryCard.tsx
+++ b/src/components/SummaryCard.tsx
@@ -15,6 +15,8 @@ import {
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import Ionicons from '@expo/vector-icons/Ionicons';
+import { useNavigation } from '@react-navigation/native';
+import { useUser } from '../context/UserContext';
 
 const { width, height } = Dimensions.get('window');
 const STATUS_BAR_HEIGHT = Platform.OS === 'android'
@@ -58,6 +60,9 @@ export default function SummaryCard() {
   const [lightness, setLightness] = useState(95);
   const hue = HUE_PRESETS[hueIndex];
   const pageBg = `hsl(${hue},30%,${lightness}%)`;
+
+  const navigation = useNavigation();
+  const { icon } = useUser();
 
   // Tasks state
   const [tasks, setTasks] = useState<TaskItem[]>([
@@ -112,8 +117,13 @@ export default function SummaryCard() {
 
       {/* Greeting Header (fixed white/light shade) */}
       <View style={styles.staticHeader}>
-        <TouchableOpacity style={styles.profileButton}>
-          <View style={styles.profileCircle}/>
+        <TouchableOpacity
+          style={styles.profileButton}
+          onPress={() => navigation.navigate('Profile')}
+        >
+          <View style={styles.profileCircle}>
+            <Ionicons name={icon as any} size={32} color="#333" />
+          </View>
         </TouchableOpacity>
         <View style={styles.headerTextContainer}>
           <Text style={styles.greetingText}>Hello, Adithyaa</Text>
@@ -311,7 +321,7 @@ const styles = StyleSheet.create({
     borderRadius:28,
     overflow:'hidden',
   },
-  profileCircle: { flex:1, backgroundColor:'#ccc' },
+  profileCircle: { flex:1, backgroundColor:'#ccc', justifyContent:'center', alignItems:'center' },
   headerTextContainer: { marginLeft:0 },
   greetingText: { color:'#333', fontSize:26, fontWeight:'700' },
   dateText:   { color:'#666', fontSize:12, fontWeight:'700', marginTop:4 },

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -1,0 +1,27 @@
+import React, { createContext, useContext, useState } from 'react';
+
+export type UserContextType = {
+  icon: string;
+  setIcon: (icon: string) => void;
+};
+
+const UserContext = createContext<UserContextType | undefined>(undefined);
+
+export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [icon, setIcon] = useState<string>('person-circle');
+  return (
+    <UserContext.Provider value={{ icon, setIcon }}>
+      {children}
+    </UserContext.Provider>
+  );
+};
+
+export const useUser = () => {
+  const ctx = useContext(UserContext);
+  if (!ctx) {
+    throw new Error('useUser must be used within a UserProvider');
+  }
+  return ctx;
+};
+
+export default UserContext;

--- a/src/screens/Profile.tsx
+++ b/src/screens/Profile.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { View, Text, StyleSheet, FlatList, TouchableOpacity } from 'react-native';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { useUser } from '../context/UserContext';
+
+const ICON_CHOICES = [
+  'person-circle',
+  'happy',
+  'cafe',
+  'planet',
+  'school',
+];
+
+export default function Profile() {
+  const { icon, setIcon } = useUser();
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Profile</Text>
+      <View style={styles.preview}>
+        <Ionicons name={icon as any} size={80} color="#333" />
+      </View>
+      <Text style={styles.subtitle}>Choose your icon</Text>
+      <FlatList
+        data={ICON_CHOICES}
+        horizontal
+        keyExtractor={(item) => item}
+        showsHorizontalScrollIndicator={false}
+        renderItem={({ item }) => (
+          <TouchableOpacity
+            style={[styles.iconOption, item === icon && styles.selected]}
+            onPress={() => setIcon(item)}
+          >
+            <Ionicons name={item as any} size={40} color="#333" />
+          </TouchableOpacity>
+        )}
+      />
+      <View style={styles.details}>
+        <Text style={styles.detailText}>Name: Adithyaa</Text>
+        <Text style={styles.detailText}>Email: adithyaa@example.com</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    padding: 16,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    marginBottom: 12,
+  },
+  preview: {
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  subtitle: {
+    fontSize: 18,
+    marginBottom: 8,
+  },
+  iconOption: {
+    padding: 8,
+    marginRight: 12,
+    borderRadius: 8,
+    backgroundColor: '#eee',
+  },
+  selected: {
+    backgroundColor: '#ddd',
+  },
+  details: {
+    marginTop: 24,
+  },
+  detailText: {
+    fontSize: 16,
+    marginBottom: 4,
+  },
+});


### PR DESCRIPTION
## Summary
- add user context to store selected profile icon
- create Profile screen with icon selection
- hook profile button on home card to navigate to Profile
- show chosen icon in home header

## Testing
- `npx tsc -noEmit` *(fails: Cannot find module '@expo/vector-icons/Ionicons' or its corresponding type declarations)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6848440666c4832f94cf13363ae4b20c