### PR TITLE
Fix capture button runtime error

### DIFF
--- a/src/components/CameraModal.tsx
+++ b/src/components/CameraModal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Modal, View, TouchableOpacity, StyleSheet, Text } from 'react-native';
-import { Camera, CameraView, CameraType, FocusMode } from 'expo-camera';
+import { Camera, CameraView } from 'expo-camera';
 import * as MediaLibrary from 'expo-media-library';
 
 export type CameraModalProps = {
@@ -39,8 +39,8 @@ export default function CameraModal({ visible, onClose, onCapture }: CameraModal
           <CameraView
             ref={cameraRef}
             style={StyleSheet.absoluteFill}
-            facing={CameraType.back}
-            autofocus={FocusMode.on}
+            facing="back"
+            autofocus="on"
           />
         )}
         <View style={styles.bottomBar}>


### PR DESCRIPTION
## Summary
- ensure `CameraView` uses string props instead of undefined constants

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684844fcd9c8832f9fae5b71b9741cae