### PR TITLE
Fix menu grid spacing

### DIFF
--- a/src/components/SummaryCard.tsx
+++ b/src/components/SummaryCard.tsx
@@ -390,8 +390,8 @@ const styles = StyleSheet.create({
 
   menuGrid: { flexDirection:'row', flexWrap:'wrap', justifyContent:'space-between' },
   menuBox:  {
-    // use percentage width for more flexible two-column layout
-    width: '48%',
+    // adjust width so two menu items fit side‑by‑side
+    width: '46%',
     backgroundColor:'#fff',
     borderRadius:12,
     padding:12,


### PR DESCRIPTION
## Summary
- allow today's menu items to sit two per row by reducing box width

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_684846f648a4832faa4b693fc0cd1784