### PR TITLE
Improve back schedule UI

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -27,6 +27,17 @@ export const CARD_HEIGHT = SCREEN_HEIGHT * 0.60;
 /** Number of raindrops */
 const RAINDROP_COUNT = 12;
 
+function isClassOver(timeRange: string) {
+  const parts = timeRange.split('–').map((s) => s.trim());
+  if (parts.length !== 2) return false;
+  const [_start, end] = parts;
+  const [endH, endM] = end.split(':').map(Number);
+  const now = new Date();
+  const nowMinutes = now.getHours() * 60 + now.getMinutes();
+  const endMinutes = endH * 60 + endM;
+  return nowMinutes > endMinutes;
+}
+
 /** More “painterly” multi-stop gradients */
 export const GRADIENTS = [
   ['#8E44AD', '#C0392B', '#F39C12'],  // rich purples, reds, ochre
@@ -193,9 +204,9 @@ export default function Card({
             <View style={styles.contentContainer}>
               <Text style={styles.courseText}>{courseCode}</Text>
               {roomDetail !== '' && (
-                <Text style={styles.roomText}>{roomDetail}</Text>
+                <Text style={styles.roomText} numberOfLines={1}>{roomDetail}</Text>
               )}
-              <Text style={styles.timeText}>{time}</Text>
+              <Text style={styles.timeText} numberOfLines={1}>{time}</Text>
             </View>
 
             {/* BUTTON BAR */}
@@ -250,12 +261,17 @@ export default function Card({
             <View style={styles.contentContainer}>
               <View style={styles.backContent}>
                 <Text style={styles.backHeader}>Today's Schedule</Text>
-                {daySchedule.map((cls, idx) => (
-                  <View key={idx} style={styles.backRow}>
-                    <Text style={styles.backTime}>{cls.time}</Text>
-                    <Text style={styles.backTitle}>{cls.title}</Text>
-                  </View>
-                ))}
+                {daySchedule.map((cls, idx) => {
+                  const parts = cls.title.split('@').map((p) => p.trim());
+                  const display = parts.length > 1 ? `${parts[0]} • ${parts[1]}` : cls.title;
+                  const past = isClassOver(cls.time);
+                  return (
+                    <View key={idx} style={styles.backRow}>
+                      <Text style={styles.backTime}>{cls.time}</Text>
+                      <Text style={[styles.backTitle, past && styles.pastTitle]}>{display}</Text>
+                    </View>
+                  );
+                })}
               </View>
             </View>
           </LinearGradient>
@@ -500,6 +516,11 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     paddingHorizontal: 24,
+    paddingVertical: 16,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.3)',
+    backgroundColor: 'rgba(0,0,0,0.25)',
     zIndex: 3,
   },
   backHeader: {
@@ -514,19 +535,28 @@ const styles = StyleSheet.create({
   },
   backRow: {
     flexDirection: 'row',
+    alignItems: 'center',
     marginVertical: 6,
+    borderBottomWidth: 1,
+    borderBottomColor: 'rgba(255,255,255,0.2)',
+    paddingBottom: 4,
   },
   backTime: {
     fontSize: 16,
     color: '#e0f0ff',
-    width: 100,
+    width: 90,
     fontWeight: '600',
+    marginRight: 8,
   },
   backTitle: {
     fontSize: 16,
     color: '#fff',
     flex: 1,
     fontWeight: '500',
+    flexWrap: 'nowrap',
+  },
+  pastTitle: {
+    color: '#ff6666',
   },
   buttonBar: {
     position: 'absolute',


### PR DESCRIPTION
## Summary
- polish the schedule on the back of each card
  - indicate past classes in red
  - replace `@` with a bullet
  - add borders and padding
  - keep timeline on one line
- ensure the front side time and room text do not wrap

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6848496598f0832f9cdd09e17705d682