### PR TITLE
Add header color controls

### DIFF
--- a/src/components/SummaryCard.tsx
+++ b/src/components/SummaryCard.tsx
@@ -61,6 +61,12 @@ export default function SummaryCard() {
   const hue = HUE_PRESETS[hueIndex];
   const pageBg = `hsl(${hue},30%,${lightness}%)`;
 
+  // Header background HSL
+  const [headerHueIndex, setHeaderHueIndex] = useState(0);
+  const [headerLightness, setHeaderLightness] = useState(100);
+  const headerHue = HUE_PRESETS[headerHueIndex];
+  const headerBg = `hsl(${headerHue},30%,${headerLightness}%)`;
+
   const navigation = useNavigation();
   const { icon } = useUser();
 
@@ -111,12 +117,17 @@ export default function SummaryCard() {
   const lighten = () => setLightness(l=>Math.min(l+5,100));
   const darken  = () => setLightness(l=>Math.max(l-5,0));
 
+  // Header color handlers
+  const cycleHeaderHue = () => setHeaderHueIndex(i=>(i+1)%HUE_PRESETS.length);
+  const lightenHeader = () => setHeaderLightness(l=>Math.min(l+5,100));
+  const darkenHeader  = () => setHeaderLightness(l=>Math.max(l-5,0));
+
   return (
     <SafeAreaView style={[styles.safe, { backgroundColor: pageBg }]}>
       <StatusBar translucent backgroundColor="transparent" barStyle="dark-content"/>
 
-      {/* Greeting Header (fixed white/light shade) */}
-      <View style={styles.staticHeader}>
+      {/* Greeting Header (adjustable color) */}
+      <View style={[styles.staticHeader, { backgroundColor: headerBg }]}>
         <TouchableOpacity
           style={styles.profileButton}
           onPress={() => navigation.navigate('Profile')}
@@ -129,7 +140,20 @@ export default function SummaryCard() {
           <Text style={styles.greetingText}>Hello, Adithyaa</Text>
           <Text style={styles.dateText}>Saturday, June 7, 2025</Text>
         </View>
-        {/* Color controls apply to page */}
+        {/* Header color controls */}
+        <View style={styles.headerColorControls}>
+          <TouchableOpacity onPress={cycleHeaderHue} style={styles.controlButton}>
+            <Text style={styles.controlText}>🎨</Text>
+          </TouchableOpacity>
+          <TouchableOpacity onPress={lightenHeader} style={styles.controlButton}>
+            <Text style={styles.controlText}>☀️</Text>
+          </TouchableOpacity>
+          <TouchableOpacity onPress={darkenHeader} style={styles.controlButton}>
+            <Text style={styles.controlText}>🌙</Text>
+          </TouchableOpacity>
+        </View>
+
+        {/* Page color controls */}
         <View style={styles.colorControls}>
           <TouchableOpacity onPress={cycleHue} style={styles.controlButton}>
             <Text style={styles.controlText}>🎨</Text>
@@ -307,7 +331,6 @@ const styles = StyleSheet.create({
   safe: { flex:1 },
 
   staticHeader: {
-    backgroundColor: '#fff',
     paddingTop: STATUS_BAR_HEIGHT + 12,
     paddingHorizontal:24,
     paddingBottom:12,
@@ -325,6 +348,13 @@ const styles = StyleSheet.create({
   headerTextContainer: { marginLeft:0 },
   greetingText: { color:'#333', fontSize:26, fontWeight:'700' },
   dateText:   { color:'#666', fontSize:12, fontWeight:'700', marginTop:4 },
+
+  headerColorControls: {
+    flexDirection:'row',
+    position:'absolute',
+    bottom:12,
+    left:24,
+  },
 
   colorControls: { flexDirection:'row', position:'absolute', bottom:12, right:24 },
   controlButton: { marginLeft:12 },


### PR DESCRIPTION
## Summary
- let home page header color be adjusted
- add header color state and buttons to cycle and lighten/darken the header
- keep previous page color controls as well

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: expo/tsconfig.base not found and FoodMenuScreen.tsx error)*

------
https://chatgpt.com/codex/tasks/task_e_68484ce96418832f87ed616018bfad82