### PR TITLE
Handle missing watch directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "postinstall": "patch-package"
   },
   "dependencies": {
     "@expo/metro-runtime": "~5.0.4",
@@ -51,7 +52,8 @@
     "@react-native-community/cli": "^18.0.0",
     "@types/react": "~19.0.10",
     "@types/react-native": "^0.72.8",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "patch-package": "^8.0.0"
   },
   "private": true
 }

--- a/patches/metro-file-map+0.82.4.patch
+++ b/patches/metro-file-map+0.82.4.patch
@@ -1,0 +1,34 @@
+diff --git a/node_modules/metro-file-map/src/watchers/FallbackWatcher.js b/node_modules/metro-file-map/src/watchers/FallbackWatcher.js
+index 75ac8a0..0a69b92 100644
+--- a/node_modules/metro-file-map/src/watchers/FallbackWatcher.js
++++ b/node_modules/metro-file-map/src/watchers/FallbackWatcher.js
+@@ -85,13 +85,22 @@ module.exports = class FallbackWatcher extends AbstractWatcher {
+     if (this.watched[dir]) {
+       return false;
+     }
+-    const watcher = fs.watch(
+-      dir,
+-      {
+-        persistent: true,
+-      },
+-      (event, filename) => this._normalizeChange(dir, event, filename)
+-    );
++    if (!fs.existsSync(dir)) {
++      return false;
++    }
++    let watcher;
++    try {
++      watcher = fs.watch(
++        dir,
++        {
++          persistent: true,
++        },
++        (event, filename) => this._normalizeChange(dir, event, filename)
++      );
++    } catch (error) {
++      this._checkedEmitError(error);
++      return false;
++    }
+     this.watched[dir] = watcher;
+     watcher.on("error", this._checkedEmitError);
+     if (this.root !== dir) {


### PR DESCRIPTION
## Summary
- install `patch-package` and run after installs
- patch Metro's FallbackWatcher to check that a directory exists before watching and handle errors

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848517bbf68832f90d2ce9d5409b9ab