### PR TITLE
Fix duplicate properties in Card.tsx

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -535,19 +535,11 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     paddingHorizontal: 24,
-    paddingVertical: 24,
-    borderRadius: 16,
-    borderWidth: 1,
-    borderColor: 'rgba(255,255,255,0.3)',
-
     paddingVertical: 16,
     borderRadius: 16,
     borderWidth: 1,
     borderColor: 'rgba(255,255,255,0.3)',
-
     backgroundColor: 'rgba(0,0,0,0.25)',
-
-
     zIndex: 3,
   },
   backHeader: {
@@ -582,12 +574,6 @@ const styles = StyleSheet.create({
     color: '#e0f0ff',
     width: 110,
     fontWeight: '700',
-
-
-    width: 90,
-
-    fontWeight: '600',
-
     marginRight: 8,
   },
   backTitle: {


### PR DESCRIPTION
## Summary
- remove duplicate properties in `backContent` and `backTime` styles

## Testing
- `npx tsc src/components/Card.tsx --jsx react --noEmit` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_684851448c04832f9500e0aa977c1731