### PR TITLE
Fix FoodMenuScreen parse error

### DIFF
--- a/src/screens/FoodMenuScreen.tsx
+++ b/src/screens/FoodMenuScreen.tsx
@@ -232,7 +232,7 @@ export default function FoodMenuScreen({ navigation }: any) {
                     )}
                   </View>
                 );
-              });
+              })}
             </Animated.View>
           );
         })}


### PR DESCRIPTION
## Summary
- fix missing closing brace in `FoodMenuScreen`

## Testing
- `npx tsc src/screens/FoodMenuScreen.tsx --jsx react --noEmit`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848535e2670832f990d154114777c31