### PR TITLE
Fix gesture setup for navigation

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
+import 'react-native-gesture-handler';
 import { registerRootComponent } from 'expo';
 
 import App from './App';


### PR DESCRIPTION
## Summary
- import `react-native-gesture-handler` in entry

## Testing
- `npm run web` *(fails: expo missing, requires install)*

------
https://chatgpt.com/codex/tasks/task_e_684855143e98832fac1a56e579626984