### PR TITLE
Fix gesture setup for navigation

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,6 +3,10 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { enableScreens } from 'react-native-screens';
+
+enableScreens();
 import { NavigationContainer } from '@react-navigation/native';
 import {
   createNativeStackNavigator,
@@ -113,17 +117,19 @@ function MainTabs() {
 
 export default function App() {
   return (
-    <SafeAreaProvider>
-      <NavigationContainer>
-        <RootStack.Navigator screenOptions={{ headerShown: false }}>
-          <RootStack.Screen name="MainTabs" component={MainTabs} />
-          <RootStack.Screen
-            name="FoodMenuScreen"
-            component={FoodMenuScreen}
-          />
-        </RootStack.Navigator>
-      </NavigationContainer>
-    </SafeAreaProvider>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <SafeAreaProvider>
+        <NavigationContainer>
+          <RootStack.Navigator screenOptions={{ headerShown: false }}>
+            <RootStack.Screen name="MainTabs" component={MainTabs} />
+            <RootStack.Screen
+              name="FoodMenuScreen"
+              component={FoodMenuScreen}
+            />
+          </RootStack.Navigator>
+        </NavigationContainer>
+      </SafeAreaProvider>
+    </GestureHandlerRootView>
   );
 }
 

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,5 @@
+import 'react-native-reanimated';
+import 'react-native-gesture-handler';
 import { registerRootComponent } from 'expo';
 
 import App from './App';


### PR DESCRIPTION
## Summary
- register `enableScreens()` and wrap app in `GestureHandlerRootView`
- ensure `react-native-reanimated` initializes before `react-native-gesture-handler`

## Testing
- ❌ `npx expo --version` *(failed: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_684855143e98832fac1a56e579626984