### PR TITLE
Disable native driver animations

### DIFF
--- a/src/components/BottomPanel.tsx
+++ b/src/components/BottomPanel.tsx
@@ -62,7 +62,7 @@ const BottomPanel = forwardRef<BottomPanelHandle, Props>(
         Animated.timing(slide, {
           toValue: 1,
           duration: 150, // faster open
-          useNativeDriver: true,
+          useNativeDriver: false,
         }).start();
       }
     }, [isVisible, slide]);
@@ -72,7 +72,7 @@ const BottomPanel = forwardRef<BottomPanelHandle, Props>(
       Animated.timing(slide, {
         toValue: 0,
         duration: 150, // faster close
-        useNativeDriver: true,
+        useNativeDriver: false,
       }).start(() => {
         onDismiss();
       });

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -119,7 +119,7 @@ export default function Card({
     Animated.timing(flipAnim, {
       toValue: flipped ? 0 : 180,
       duration: 350,
-      useNativeDriver: true,
+      useNativeDriver: false,
       easing: Easing.inOut(Easing.ease),
     }).start(() => setFlipped(!flipped));
   };
@@ -337,24 +337,24 @@ function Raindrops() {
     drops.forEach(({ anim, delay, speed }) => {
       const loop = () => {
         anim.setValue(-20);
-        Animated.timing(anim, {
-          toValue: CARD_HEIGHT + 20,
-          duration: speed,
-          delay,
-          easing: Easing.linear,
-          useNativeDriver: true,
-        }).start(({ finished }) => {
+          Animated.timing(anim, {
+            toValue: CARD_HEIGHT + 20,
+            duration: speed,
+            delay,
+            easing: Easing.linear,
+            useNativeDriver: false,
+          }).start(({ finished }) => {
           if (finished) {
             const newSpeed = 1800 + Math.random() * 800;
             const newDelay = Math.random() * 1200;
             anim.setValue(-20);
-            Animated.timing(anim, {
-              toValue: CARD_HEIGHT + 20,
-              duration: newSpeed,
-              delay: newDelay,
-              easing: Easing.linear,
-              useNativeDriver: true,
-            }).start(({ finished: f2 }) => {
+              Animated.timing(anim, {
+                toValue: CARD_HEIGHT + 20,
+                duration: newSpeed,
+                delay: newDelay,
+                easing: Easing.linear,
+                useNativeDriver: false,
+              }).start(({ finished: f2 }) => {
               if (f2) loop();
             });
           }

--- a/src/components/SummaryCard.tsx
+++ b/src/components/SummaryCard.tsx
@@ -141,12 +141,12 @@ export default function SummaryCard() {
 
   useEffect(() => {
     classAnims.forEach((anim, i) => {
-      Animated.timing(anim, {
-        toValue: 1,
-        duration: 400,
-        delay: i * 100,
-        useNativeDriver: true,
-      }).start();
+        Animated.timing(anim, {
+          toValue: 1,
+          duration: 400,
+          delay: i * 100,
+          useNativeDriver: false,
+        }).start();
     });
   }, [classAnims]);
 

--- a/src/components/WhatsNextPanel.tsx
+++ b/src/components/WhatsNextPanel.tsx
@@ -63,7 +63,7 @@ const WhatsNextPanel = forwardRef<WhatsNextPanelHandle, Props>(
         Animated.timing(slide, {
           toValue: 1,
           duration: 150,
-          useNativeDriver: true,
+          useNativeDriver: false,
         }).start();
       }
     }, [isVisible, slide]);
@@ -74,7 +74,7 @@ const WhatsNextPanel = forwardRef<WhatsNextPanelHandle, Props>(
         Animated.timing(slide, {
           toValue: 0,
           duration: 150,
-          useNativeDriver: true,
+          useNativeDriver: false,
         }).start(() => {
           onDismiss();
         });
@@ -209,7 +209,7 @@ const WhatsNextPanel = forwardRef<WhatsNextPanelHandle, Props>(
             Animated.timing(slide, {
               toValue: 0,
               duration: 150,
-              useNativeDriver: true,
+              useNativeDriver: false,
             }).start(() => onDismiss());
           }}
         >


### PR DESCRIPTION
## Summary
- avoid using native driver for animations

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_684863bd9f3c832fa4f76809fc7d7d9e