### PR TITLE
Disable new architecture for Expo Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,12 @@
    ```
 
 Make sure you have the Expo CLI installed and Android SDK configured.
+
+### New Architecture
+
+This project previously enabled React Native's New Architecture. Running in
+**Expo Go** does not support that setup, so `newArchEnabled` is disabled by
+default (see `app.json` and `android/gradle.properties`). If you need to use the
+new architecture or any native modules that aren't included with Expo Go, create
+a development build as described in the Expo docs:
+<https://docs.expo.dev/develop/development-builds/create-a-build/>

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -35,7 +35,7 @@ reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
 # your application. You should enable this flag either if you want
 # to write custom TurboModules/Fabric components OR use libraries that
 # are providing them.
-newArchEnabled=true
+newArchEnabled=false
 
 # Use this property to enable or disable the Hermes JS engine.
 # If set to false, you will be using JSC instead.

--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
-    "newArchEnabled": true,
+    "newArchEnabled": false,
     "splash": {
       "image": "./assets/splash-icon.png",
       "resizeMode": "contain",


### PR DESCRIPTION
## Summary
- turn off New Architecture in app config
- document why New Architecture is disabled

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68486a9626a8832faee27d14590a3c6a