### PR TITLE
Fix scroll event error in CardCarousel

### DIFF
--- a/src/components/CardCarousel.tsx
+++ b/src/components/CardCarousel.tsx
@@ -96,7 +96,9 @@ export default function CardCarousel({
         scrollEventThrottle={16}
         onScroll={Animated.event(
           [{ nativeEvent: { contentOffset: { x: scrollX } } }],
-          { useNativeDriver: false }
+          {
+            useNativeDriver: true, // avoid mutating the event object on JS thread
+          }
         )}
       >
         {cards.map((c, i) => (


### PR DESCRIPTION
## Summary
- avoid modifying immutable scroll events in new architecture by using native driver for `Animated.event`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68486ddf1554832f9c58c1d44d02b261