### PR TITLE
Fix scroll index update for native driver

### DIFF
--- a/src/components/BottomPanel.tsx
+++ b/src/components/BottomPanel.tsx
@@ -62,7 +62,7 @@ const BottomPanel = forwardRef<BottomPanelHandle, Props>(
         Animated.timing(slide, {
           toValue: 1,
           duration: 150, // faster open
-          useNativeDriver: false,
+          useNativeDriver: true,
         }).start();
       }
     }, [isVisible, slide]);
@@ -72,7 +72,7 @@ const BottomPanel = forwardRef<BottomPanelHandle, Props>(
       Animated.timing(slide, {
         toValue: 0,
         duration: 150, // faster close
-        useNativeDriver: false,
+        useNativeDriver: true,
       }).start(() => {
         onDismiss();
       });

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -119,7 +119,7 @@ export default function Card({
     Animated.timing(flipAnim, {
       toValue: flipped ? 0 : 180,
       duration: 350,
-      useNativeDriver: false,
+      useNativeDriver: true,
       easing: Easing.inOut(Easing.ease),
     }).start(() => setFlipped(!flipped));
   };
@@ -342,7 +342,7 @@ function Raindrops() {
             duration: speed,
             delay,
             easing: Easing.linear,
-            useNativeDriver: false,
+            useNativeDriver: true,
           }).start(({ finished }) => {
           if (finished) {
             const newSpeed = 1800 + Math.random() * 800;
@@ -353,7 +353,7 @@ function Raindrops() {
                 duration: newSpeed,
                 delay: newDelay,
                 easing: Easing.linear,
-                useNativeDriver: false,
+                useNativeDriver: true,
               }).start(({ finished: f2 }) => {
               if (f2) loop();
             });

--- a/src/components/CardCarousel.tsx
+++ b/src/components/CardCarousel.tsx
@@ -1,6 +1,6 @@
 // src/components/CardCarousel.tsx
 
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useRef, useState } from 'react';
 import {
   Animated,
   StyleSheet,
@@ -68,16 +68,15 @@ export default function CardCarousel({
     })
   ).current;
 
-  useEffect(() => {
-    const listener = scrollX.addListener(({ value }) => {
-      const newIndex = Math.round(value / SCREEN_WIDTH);
-      if (newIndex !== activeIndex) {
-        setActiveIndex(newIndex);
-        onIndexChange?.(newIndex);
-      }
-    });
-    return () => scrollX.removeListener(listener);
-  }, [scrollX, activeIndex, onIndexChange]);
+  // Update active index as user scrolls
+  const handleScroll = (e: any) => {
+    const value = e.nativeEvent.contentOffset.x;
+    const newIndex = Math.round(value / SCREEN_WIDTH);
+    if (newIndex !== activeIndex) {
+      setActiveIndex(newIndex);
+      onIndexChange?.(newIndex);
+    }
+  };
 
   const dotTranslate = scrollX.interpolate({
     inputRange: [0, SCREEN_WIDTH * (cards.length - 1)],
@@ -96,7 +95,10 @@ export default function CardCarousel({
         scrollEventThrottle={16}
         onScroll={Animated.event(
           [{ nativeEvent: { contentOffset: { x: scrollX } } }],
-          { useNativeDriver: false }
+          {
+            useNativeDriver: true, // avoid mutating the event object on JS thread
+            listener: handleScroll,
+          }
         )}
       >
         {cards.map((c, i) => (

--- a/src/components/SummaryCard.tsx
+++ b/src/components/SummaryCard.tsx
@@ -89,21 +89,9 @@ export default function SummaryCard() {
   // Scroll value (for future use)
   const scrollY = useRef(new Animated.Value(0)).current;
 
-  // Card gradient animation
-  const colorAnim = useRef(new Animated.Value(0)).current;
-  useEffect(() => {
-    Animated.loop(Animated.timing(colorAnim,{
-      toValue:1,duration:10000,useNativeDriver:false
-    })).start();
-  }, []);
-  const bgStart = colorAnim.interpolate({
-    inputRange:[0,0.5,1],
-    outputRange:['#FFB366','#769BE0','#FFB366'],
-  });
-  const bgEnd = colorAnim.interpolate({
-    inputRange:[0,0.5,1],
-    outputRange:['#A060E0','#7D6EB0','#A060E0'],
-  });
+  // Static gradient colors (Animated color not supported with native driver)
+  const bgStart = '#FFB366';
+  const bgEnd = '#A060E0';
 
   // Dummy schedule with icon pairs for animation
   const daySchedule: ClassItem[] = [
@@ -145,7 +133,7 @@ export default function SummaryCard() {
           toValue: 1,
           duration: 400,
           delay: i * 100,
-          useNativeDriver: false,
+          useNativeDriver: true,
         }).start();
     });
   }, [classAnims]);

--- a/src/components/TemperatureBadge.tsx
+++ b/src/components/TemperatureBadge.tsx
@@ -47,13 +47,13 @@ export default function TemperatureBadge({
           toValue: 1,
           duration: 3000,
           easing: Easing.inOut(Easing.ease),
-          useNativeDriver: false, // run on JS thread
+          useNativeDriver: true,
         }),
         Animated.timing(humidityAnim, {
           toValue: 0,
           duration: 3000,
           easing: Easing.inOut(Easing.ease),
-          useNativeDriver: false,
+          useNativeDriver: true,
         }),
       ])
     );

--- a/src/components/WhatsNextPanel.tsx
+++ b/src/components/WhatsNextPanel.tsx
@@ -63,7 +63,7 @@ const WhatsNextPanel = forwardRef<WhatsNextPanelHandle, Props>(
         Animated.timing(slide, {
           toValue: 1,
           duration: 150,
-          useNativeDriver: false,
+          useNativeDriver: true,
         }).start();
       }
     }, [isVisible, slide]);
@@ -74,7 +74,7 @@ const WhatsNextPanel = forwardRef<WhatsNextPanelHandle, Props>(
         Animated.timing(slide, {
           toValue: 0,
           duration: 150,
-          useNativeDriver: false,
+          useNativeDriver: true,
         }).start(() => {
           onDismiss();
         });
@@ -209,7 +209,7 @@ const WhatsNextPanel = forwardRef<WhatsNextPanelHandle, Props>(
             Animated.timing(slide, {
               toValue: 0,
               duration: 150,
-              useNativeDriver: false,
+              useNativeDriver: true,
             }).start(() => onDismiss());
           }}
         >


### PR DESCRIPTION
## Summary
- remove JS-driven color animation from `SummaryCard`
- switch all timing animations to `useNativeDriver: true`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68486ddf1554832f9c58c1d44d02b261