### PR TITLE
Fix bottom panel typings

### DIFF
--- a/src/components/BottomPanel.tsx
+++ b/src/components/BottomPanel.tsx
@@ -13,6 +13,8 @@ import {
   StyleSheet,
   Text,
   View,
+  NativeSyntheticEvent,
+  NativeScrollEvent,
 } from 'react-native';
 import Ionicons from '@expo/vector-icons/Ionicons';
 
@@ -48,7 +50,10 @@ type Props = {
 };
 
 const BottomPanel = forwardRef<BottomPanelHandle, Props>(
-  ({ isVisible, onDismiss }, ref) => {
+  (
+    { isVisible, onDismiss }: Props,
+    ref: React.ForwardedRef<BottomPanelHandle>
+  ) => {
     const slide = useRef(new Animated.Value(isVisible ? 1 : 0)).current;
 
     // Expose close()
@@ -101,7 +106,7 @@ const BottomPanel = forwardRef<BottomPanelHandle, Props>(
           bounces
           overScrollMode="always"
           scrollEventThrottle={16}
-          onScrollEndDrag={({ nativeEvent }) => {
+          onScrollEndDrag={({ nativeEvent }: NativeSyntheticEvent<NativeScrollEvent>) => {
             const { y } = nativeEvent.contentOffset;
             const { y: vy = 0 } = nativeEvent.velocity ?? {};
             if (y <= 0 && vy > 0.5) {


### PR DESCRIPTION
## Summary
- add forward-ref type parameters for BottomPanel
- type event parameters for `onScrollEndDrag`

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react', etc.)*
- `npm start` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684876d09124832fa8ad572aca10acd7