### PR TITLE
Update config for Expo Go's architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Make sure you have the Expo CLI installed and Android SDK configured.
 
 ### New Architecture
 
-This project previously enabled React Native's New Architecture. Running in
-**Expo Go** does not support that setup, so `newArchEnabled` is disabled by
-default (see `app.json` and `android/gradle.properties`). If you need to use the
-new architecture or any native modules that aren't included with Expo Go, create
-a development build as described in the Expo docs:
+Expo Go always runs with React Native's New Architecture enabled. Earlier
+versions of this project explicitly set `newArchEnabled: false` in `app.json`,
+but that setting is no longer required and has been removed. If you need to use
+native modules that aren't included with Expo Go, create a development build as
+described in the Expo docs:
 <https://docs.expo.dev/develop/development-builds/create-a-build/>

--- a/app.json
+++ b/app.json
@@ -6,7 +6,6 @@
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
-    "newArchEnabled": false,
     "splash": {
       "image": "./assets/splash-icon.png",
       "resizeMode": "contain",


### PR DESCRIPTION
## Summary
- remove `newArchEnabled` from `app.json`
- clarify new architecture details in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68487bbe3818832f8d1ce578f38295e6