### PR TITLE
Fix new arch config and pointer events

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,7 +6,6 @@
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
-    "newArchEnabled": false,
     "splash": {
       "image": "./assets/splash-icon.png",
       "resizeMode": "contain",

--- a/src/components/BottomPanel.tsx
+++ b/src/components/BottomPanel.tsx
@@ -91,10 +91,10 @@ const BottomPanel = forwardRef<BottomPanelHandle, Props>(
 
     return (
       <Animated.View
+        pointerEvents={isVisible ? 'auto' : 'none'}
         style={[
           styles.container,
           { transform: [{ translateY }] },
-          !isVisible && { pointerEvents: 'none' },
         ]}
       >
         <View style={styles.handleContainer}>

--- a/src/components/WhatsNextPanel.tsx
+++ b/src/components/WhatsNextPanel.tsx
@@ -162,6 +162,7 @@ const WhatsNextPanel = forwardRef<WhatsNextPanelHandle, Props>(
     // If not visible, disable touches
     return (
       <Animated.View
+        pointerEvents={isVisible ? 'auto' : 'none'}
         style={[
           styles.container,
           {
@@ -177,7 +178,6 @@ const WhatsNextPanel = forwardRef<WhatsNextPanelHandle, Props>(
               },
             ],
           },
-          !isVisible && { pointerEvents: 'none' },
         ]}
       >
         {/* Handle bar and swipe-up listener */}


### PR DESCRIPTION
## Summary
- remove `newArchEnabled` entry from Expo config to match Expo Go
- disable touch handling via `pointerEvents` prop instead of style to avoid React 19 errors

## Testing
- `npx expo --version` *(fails: package not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68487aeee84c832f9d34a2ce5955f0c9