### PR TITLE
Fix peer dependency warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@react-navigation/native": "^7.1.10",
         "@react-navigation/native-stack": "^7.3.14",
         "@react-navigation/stack": "^7.3.3",
-        "@shopify/react-native-skia": "v2.0.0-next.4",
+        "@shopify/react-native-skia": "^2.0.3",
         "expo": "^53.0.10",
         "expo-blur": "~14.1.5",
         "expo-camera": "~16.1.7",
@@ -3675,9 +3675,9 @@
       }
     },
     "node_modules/@shopify/react-native-skia": {
-      "version": "2.0.0-next.4",
-      "resolved": "https://registry.npmjs.org/@shopify/react-native-skia/-/react-native-skia-2.0.0-next.4.tgz",
-      "integrity": "sha512-NzvdgryRz6tkKMHgCChCKa3wXfN9TZhlV0/LrfIU/wKLC1uKgGXkoZgNz7Is0wwdhtao1JJJJ81fqHCGHgzk9g==",
+  "version": "2.0.3",
+  "resolved": "https://registry.npmjs.org/@shopify/react-native-skia/-/react-native-skia-2.0.3.tgz",
+  "integrity": "sha512-OCyfHxdGvuHWLUsuvz/CCHFaOVi4iemWsM/5DM6vHNQpm+xwpAg6w/WAzlO+DipUoUJSoADJKj2FGj+DLn3+Kw==",
       "license": "MIT",
       "dependencies": {
         "canvaskit-wasm": "0.40.0",
@@ -9411,7 +9411,7 @@
       "integrity": "sha512-2oTvvyDy5Yj0dOwALP9x+Ijxya58hC8zAEQNS/z7uWr/63i/OYzkVkvsG0POJQDyeKvbbuLKDHia0sjUcpy4FQ==",
       "license": "MIT",
       "dependencies": {
-        "@shopify/react-native-skia": "^1.2.3"
+        "@shopify/react-native-skia": "^2.0.3"
       },
       "engines": {
         "node": ">= 18.0.0"
@@ -9429,9 +9429,9 @@
       }
     },
     "node_modules/react-native-skottie/node_modules/@shopify/react-native-skia": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/@shopify/react-native-skia/-/react-native-skia-1.12.4.tgz",
-      "integrity": "sha512-8QDIBKSU7XB3Lc1kAv4jSFddTQK8AE+1AEoJnQLNllsiex1gufLQ8kN7rs9zii+iboSY8tYKT7ocV+5cE2Exdw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@shopify/react-native-skia/-/react-native-skia-2.0.3.tgz",
+      "integrity": "sha512-OCyfHxdGvuHWLUsuvz/CCHFaOVi4iemWsM/5DM6vHNQpm+xwpAg6w/WAzlO+DipUoUJSoADJKj2FGj+DLn3+Kw==",
       "license": "MIT",
       "dependencies": {
         "canvaskit-wasm": "0.40.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@react-navigation/native": "^7.1.10",
     "@react-navigation/native-stack": "^7.3.14",
     "@react-navigation/stack": "^7.3.3",
-    "@shopify/react-native-skia": "v2.0.0-next.4",
+    "@shopify/react-native-skia": "^2.0.3",
     "expo": "^53.0.10",
     "expo-blur": "~14.1.5",
     "expo-camera": "~16.1.7",
@@ -53,6 +53,11 @@
     "@types/react-native": "^0.72.8",
     "typescript": "~5.8.3",
     "patch-package": "^8.0.0"
+  },
+  "overrides": {
+    "react-native-skottie": {
+      "@shopify/react-native-skia": "^2.0.3"
+    }
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- bump `@shopify/react-native-skia` to `^2.0.3`
- override nested `react-native-skottie` copy of Skia to `^2.0.3`

## Testing
- `npm view @shopify/react-native-skia@2.0.3 dist.integrity`

------
https://chatgpt.com/codex/tasks/task_e_68487bc65b7c832fbf2e5b87d070b8b9