### PR TITLE
Patch react-native-svg entry path

### DIFF
--- a/patches/react-native-svg+15.11.2.patch
+++ b/patches/react-native-svg+15.11.2.patch
@@ -1,0 +1,6 @@
+*** Begin Patch
+*** Update File: node_modules/react-native-svg/package.json
+@@
+-  "react-native": "src/index.ts",
++  "react-native": "lib/commonjs/index.js",
+*** End Patch


### PR DESCRIPTION
## Summary
- patch `react-native-svg` so the `react-native` entry points to the compiled JS

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684880601d68832faede6f2c6ccd070e