### PR TITLE
Add swipe calendar and menu styling tweaks

### DIFF
--- a/src/components/WhatsNextPanel.tsx
+++ b/src/components/WhatsNextPanel.tsx
@@ -204,7 +204,7 @@ const WhatsNextPanel = forwardRef<WhatsNextPanelHandle, Props>(
           style={styles.fullMenuButton}
           onPress={() => {
 
-            navigation.getParent()?.navigate('FoodMenuScreen');
+            navigation.navigate('Food');
 
             Animated.timing(slide, {
               toValue: 0,


### PR DESCRIPTION
## Summary
- hook swipe gestures to change day in `FoodMenuScreen`
- display a calendar strip with oval date highlights
- show meal ratings beside highlighted items
- add monthly summary bar and clean up menu layout
- open the Food tab when pressing *View Full Menu*
- fix stray closing brace in menu render

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848953c3e74832fbec767d63f539618