### PR TITLE
Fix syntax errors in FoodMenuScreen

### DIFF
--- a/src/screens/FoodMenuScreen.tsx
+++ b/src/screens/FoodMenuScreen.tsx
@@ -180,24 +180,6 @@ export default function FoodMenuScreen({ navigation }: any) {
           return (
             <TouchableOpacity
               key={d.toDateString()}
-              style={[styles.calendarDay, isSelected && styles.calendarSelected]}
-              onPress={() => setSelectedDate(d)}
-            >
-              <Text style={styles.calendarDayOfWeek}>
-                {d.toLocaleDateString('en-US', { weekday: 'short' })}
-              </Text>
-              <Text style={styles.calendarDate}>{d.getDate()}</Text>
-            </TouchableOpacity>
-          );
-        })}
-      </ScrollView>
-      <ScrollView contentContainerStyle={styles.content}>
-        {MEALS.map((meal) => {
-          const timer = timers[meal.name] || '';
-          const status = statuses[meal.name];
-          return (
-            <TouchableOpacity
-              key={d.toDateString()}
               style={styles.calendarDay}
               onPress={() => setSelectedDate(d)}
             >
@@ -283,11 +265,7 @@ export default function FoodMenuScreen({ navigation }: any) {
               })
             </Animated.View>
           );
-
         })
-
-        })}
-
         </ScrollView>
       </View>
       <View style={styles.summaryBar}>
@@ -424,9 +402,6 @@ const styles = StyleSheet.create({
   },
   calendarRow: {
     paddingVertical: 8,
-  calendarRow: {
-    borderBottomWidth: 1,
-    borderColor: '#ddd',
   },
   calendarContent: {
     paddingHorizontal: 8,
@@ -444,9 +419,6 @@ const styles = StyleSheet.create({
   },
   calendarSelected: {
     backgroundColor: '#d0d0d0',
-  calendarSelected: {
-    backgroundColor: '#e0e0e0',
-    borderRadius: 8,
   },
   calendarDayOfWeek: {
     fontSize: 12,


### PR DESCRIPTION
## Summary
- remove duplicated JSX blocks causing syntax errors in FoodMenuScreen

## Testing
- `npx tsc --noEmit --pretty false` *(fails: File 'expo/tsconfig.base' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68489c2d01b4832f8940a6a32b4dd86d