### PR TITLE
Fix card swipe lag

### DIFF
--- a/src/components/CardCarousel.tsx
+++ b/src/components/CardCarousel.tsx
@@ -96,7 +96,7 @@ export default function CardCarousel({
         scrollEventThrottle={16}
         onScroll={Animated.event(
           [{ nativeEvent: { contentOffset: { x: scrollX } } }],
-          { useNativeDriver: false }
+          { useNativeDriver: true }
         )}
       >
         {cards.map((c, i) => (


### PR DESCRIPTION
## Summary
- use the native driver for the carousel scroll animation

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6848a2a4540c832fad9285d517e81719