### PR TITLE
Fix double date update logic

### DIFF
--- a/src/screens/FoodMenuScreen.tsx
+++ b/src/screens/FoodMenuScreen.tsx
@@ -162,8 +162,6 @@ export default function FoodMenuScreen({ navigation }: any) {
           setSelectedDate((prev) => {
             const n = new Date(prev);
             n.setDate(prev.getDate() - 1);
-            // Swiping left should move forward a day and right should go back
-            n.setDate(prev.getDate() + (g.dx < 0 ? 1 : -1));
             return n;
           });
         }


### PR DESCRIPTION
## Summary
- correct swipe logic in `FoodMenuScreen` so date is only changed once when swiping

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json` *(fails: several TS errors and missing expo config)*

------
https://chatgpt.com/codex/tasks/task_e_68492b4c7678832f9376a385bbf5a3ae