### PR TITLE
Implement centered date scroll and monthly menu import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "expo": "^53.0.10",
         "expo-blur": "~14.1.5",
         "expo-camera": "~16.1.7",
+        "expo-document-picker": "^13.1.5",
         "expo-image-picker": "~16.1.4",
         "expo-linear-gradient": "~14.1.5",
         "expo-location": "~18.1.5",
@@ -5704,6 +5705,15 @@
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-document-picker": {
+      "version": "13.1.5",
+      "resolved": "https://registry.npmjs.org/expo-document-picker/-/expo-document-picker-13.1.5.tgz",
+      "integrity": "sha512-ELsGFW+k6xEkz7YKpop9u+9M9yUTNNruQdyKd2lSGR4thQFKRPOmKDsgYDZxc18hysGQN4evzp54lZqQwYdk4Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-file-system": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "expo": "^53.0.10",
     "expo-blur": "~14.1.5",
     "expo-camera": "~16.1.7",
+    "expo-document-picker": "^13.1.5",
     "expo-image-picker": "~16.1.4",
     "expo-linear-gradient": "~14.1.5",
     "expo-location": "~18.1.5",


### PR DESCRIPTION
## Summary
- center date highlight while swiping the calendar
- allow importing a monthly food menu from a JSON file
- remove the menu white background
- add expo-document-picker dependency

## Testing
- `npm install expo-document-picker`
- `npx tsc --noEmit` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_684934032a60832f9d17270cd417110b