### PR TITLE
Center selected date on FoodMenu

### DIFF
--- a/src/screens/FoodMenuScreen.tsx
+++ b/src/screens/FoodMenuScreen.tsx
@@ -264,7 +264,10 @@ export default function FoodMenuScreen({ navigation }: any) {
         horizontal
         showsHorizontalScrollIndicator={false}
         style={styles.calendarRow}
-        contentContainerStyle={styles.calendarContent}
+        contentContainerStyle={[
+          styles.calendarContent,
+          { paddingHorizontal: width / 2 - dayWidth / 2 },
+        ]}
       >
         {calendarDates.map((d) => {
           const isSelected = d.toDateString() === selectedDate.toDateString();
@@ -523,16 +526,15 @@ const styles = StyleSheet.create({
     alignItems: "center",
   },
   dateOval: {
-    paddingHorizontal: 16,
-    paddingVertical: 6,
-    borderRadius: 20,
+    paddingHorizontal: 8,
+    paddingVertical: 12,
+    borderRadius: 24,
     backgroundColor: "#000",
   },
   calendarSelected: {
     backgroundColor: "#fff",
     borderWidth: 2,
     borderColor: "#000",
-    transform: [{ scale: 1.2 }],
   },
   calendarDayOfWeek: {
     fontSize: 14,


### PR DESCRIPTION
## Summary
- keep selected date centered in FoodMenu calendar
- resize date highlight and orient oval vertically

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*

------
https://chatgpt.com/codex/tasks/task_e_68493ab12818832faf8b9dbaca3597ba