### PR TITLE
Fix missing slideAnim ref

### DIFF
--- a/src/screens/FoodMenuScreen.tsx
+++ b/src/screens/FoodMenuScreen.tsx
@@ -92,6 +92,7 @@ export default function FoodMenuScreen({ navigation }: any) {
 
   const calendarRef = useRef<ScrollView>(null);
   const menuAnim = useRef(new Animated.Value(0)).current;
+  const slideAnim = useRef(new Animated.Value(0)).current;
   const prevDateIdx = useRef(
     calendarDates.findIndex((d) => d.toDateString() === today.toDateString()),
   );


### PR DESCRIPTION
## Summary
- fix undefined variable crash by defining `slideAnim` animated value

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: cannot find expo tsconfig and modules)*
- `npx eslint src/screens/FoodMenuScreen.tsx` *(fails: no ESLint config)*


------
https://chatgpt.com/codex/tasks/task_e_684942bee470832f8811d2d658f36717