### PR TITLE
Fix menu screen syntax

### DIFF
--- a/src/screens/MonthlyMenuScreen.tsx
+++ b/src/screens/MonthlyMenuScreen.tsx
@@ -22,7 +22,6 @@ export default function MonthlyMenuScreen() {
   // Use the bundled data initially so the monthly view works offline
   const [menu, setMenu] = useState<MonthlyMenu>(localMenu as MonthlyMenu);
 
-  const [menu, setMenu] = useState<MonthlyMenu | null>(null);
 
   const [loading, setLoading] = useState(true);
 


### PR DESCRIPTION
## Summary
- fix duplicate state definition in monthly menu screen

## Testing
- `jq empty monthly-menu-may-2025.json`


------
https://chatgpt.com/codex/tasks/task_e_684986397fd8832f80e6105c3e14bf52