### PR TITLE
Update Food Menu design and add summary screen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -15,6 +15,7 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import Home from './src/screens/Home';
 import FoodMenuScreen from './src/screens/FoodMenuScreen';
 import MonthlyMenuScreen from './src/screens/MonthlyMenuScreen';
+import FoodSummaryScreen from './src/screens/FoodSummaryScreen';
 
 // Placeholders or existing components for other tabs:
 function PlannerScreen() {
@@ -47,6 +48,7 @@ type RootStackParamList = {
   MainTabs: undefined;
   FoodMenuScreen: undefined;
   MonthlyMenuScreen: undefined;
+  FoodSummaryScreen: undefined;
   Profile: undefined;
 };
 
@@ -134,6 +136,10 @@ export default function App() {
           <RootStack.Screen
             name="MonthlyMenuScreen"
             component={MonthlyMenuScreen}
+          />
+          <RootStack.Screen
+            name="FoodSummaryScreen"
+            component={FoodSummaryScreen}
           />
           <RootStack.Screen name="Profile" component={Profile} />
           </RootStack.Navigator>

--- a/src/screens/FoodSummaryScreen.tsx
+++ b/src/screens/FoodSummaryScreen.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+export default function FoodSummaryScreen() {
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.inner}>
+        <Text style={styles.text}>Food Summary page coming soon.</Text>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#fff' },
+  inner: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  text: { fontSize: 18, color: '#333' },
+});


### PR DESCRIPTION
## Summary
- center Today's Menu heading
- style meal name chips with icons
- show countdown or Done icon next to meal name
- dim completed meal blocks
- grey buttons for links and open a new Food Summary screen
- wire up new FoodSummaryScreen in navigation

## Testing
- `npx tsc --noEmit` *(fails: expo tsconfig not found)*

------
https://chatgpt.com/codex/tasks/task_e_684997894490832fb1de81702449b46a