### PR TITLE
Enhance monthly menu styling

### DIFF
--- a/src/screens/MonthlyMenuScreen.tsx
+++ b/src/screens/MonthlyMenuScreen.tsx
@@ -1,5 +1,14 @@
-import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet, SectionList, ActivityIndicator, FlatList } from 'react-native';
+import React, { useEffect, useState, useRef } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  SectionList,
+  ActivityIndicator,
+  Pressable,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import Ionicons from '@expo/vector-icons/Ionicons';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { Meal } from '../data/meals';
 
@@ -24,6 +33,8 @@ export default function MonthlyMenuScreen() {
 
 
   const [loading, setLoading] = useState(true);
+  const [likes, setLikes] = useState<Record<string, boolean>>({});
+  const listRef = useRef<SectionList<any>>(null);
 
   useEffect(() => {
     const loadMenu = async () => {
@@ -47,6 +58,26 @@ export default function MonthlyMenuScreen() {
     loadMenu();
   }, []);
 
+  // Scroll to current day once data is loaded
+  useEffect(() => {
+    if (loading) return;
+    const todayKey = new Date().toISOString().slice(0, 10);
+    const dates = Object.keys(menu).sort();
+    const idx = dates.indexOf(todayKey);
+    if (idx >= 0) {
+      const sectionIndex = Math.floor(idx / 7);
+      const itemIndex = idx % 7;
+      setTimeout(() => {
+        listRef.current?.scrollToLocation({
+          sectionIndex,
+          itemIndex,
+          animated: false,
+          viewPosition: 0,
+        });
+      }, 0);
+    }
+  }, [loading, menu]);
+
   const toWeeks = (): WeekSection[] => {
 
     if (!menu) return [];
@@ -63,17 +94,58 @@ export default function MonthlyMenuScreen() {
     return weeks;
   };
 
-  const renderDay = ({ date, meals }: { date: string; meals: Meal[] }) => (
-    <View style={styles.dayBlock}>
-      <Text style={styles.dayHeader}>{date}</Text>
-      {meals.map(m => (
-        <View key={`${date}-${m.name}`} style={styles.mealItem}>
-          <Text style={styles.mealTitle}>{m.name}</Text>
-          <Text style={styles.mealItems}>{m.items.join(', ')}</Text>
+  const today = new Date().toISOString().slice(0, 10);
+
+  const toggleLike = (key: string) =>
+    setLikes((prev) => ({ ...prev, [key]: !prev[key] }));
+
+  const renderDay = (
+    { date, meals }: { date: string; meals: Meal[] },
+    index: number,
+    section: WeekSection
+  ) => {
+    const isPast = date < today;
+    return (
+      <View
+        style={[
+          styles.dayBlock,
+          isPast && styles.pastDay,
+          index === 0 && styles.firstDay,
+          index === section.data.length - 1 && styles.lastDay,
+        ]}
+      >
+        <View style={styles.dateChip}>
+          <Text style={styles.dateText}>{date}</Text>
         </View>
-      ))}
-    </View>
-  );
+        {meals.map((m) => {
+          const key = `${date}-${m.name}`;
+          return (
+            <View key={key} style={styles.mealItem}>
+              <View style={styles.mealHeader}>
+                <Text style={styles.mealTitle}>{m.name}</Text>
+                <View style={styles.mealActions}>
+                  <Pressable
+                    onPress={() => toggleLike(key)}
+                    style={styles.iconButton}
+                  >
+                    <Ionicons
+                      name={likes[key] ? 'heart' : 'heart-outline'}
+                      size={16}
+                      color={likes[key] ? 'red' : '#333'}
+                    />
+                  </Pressable>
+                  <Pressable style={styles.iconButton}>
+                    <Ionicons name="add" size={16} color="#333" />
+                  </Pressable>
+                </View>
+              </View>
+              <Text style={styles.mealItems}>{m.items.join(', ')}</Text>
+            </View>
+          );
+        })}
+      </View>
+    );
+  };
 
   if (loading) {
     return (
@@ -84,42 +156,76 @@ export default function MonthlyMenuScreen() {
   }
 
   return (
-    <SectionList
-      sections={toWeeks()}
-      keyExtractor={(item) => item.date}
-      renderItem={({ item }) => renderDay(item)}
-      renderSectionHeader={({ section: { title } }) => (
-        <Text style={styles.sectionHeader}>{title}</Text>
-      )}
-    />
+    <SafeAreaView style={styles.safe}>
+      <SectionList
+        ref={listRef}
+        sections={toWeeks()}
+        keyExtractor={(item) => item.date}
+        renderItem={({ item, index, section }) =>
+          renderDay(item, index, section as WeekSection)
+        }
+        renderSectionHeader={({ section: { title } }) => (
+          <View style={styles.weekHeader}>
+            <Text style={styles.sectionHeader}>{title}</Text>
+          </View>
+        )}
+        SectionSeparatorComponent={() => <View style={{ height: 12 }} />}
+        stickySectionHeadersEnabled={false}
+        contentContainerStyle={styles.listContent}
+      />
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: '#f9f9f9' },
   centered: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  listContent: { padding: 12 },
+  weekHeader: {
+    backgroundColor: '#e6e6e6',
+    padding: 8,
+    marginHorizontal: 4,
+    borderTopLeftRadius: 12,
+    borderTopRightRadius: 12,
+    alignItems: 'center',
+  },
   sectionHeader: {
-    paddingVertical: 8,
-    paddingHorizontal: 16,
-    backgroundColor: '#eee',
     fontWeight: '600',
+    fontSize: 18,
+    color: '#333',
   },
   dayBlock: {
-    padding: 16,
+    backgroundColor: '#dcdcdc',
+    padding: 12,
+    marginHorizontal: 4,
     borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: '#ccc',
+    borderBottomColor: '#bbb',
   },
-  dayHeader: {
-    fontSize: 16,
-    fontWeight: '600',
+  firstDay: { borderTopLeftRadius: 12, borderTopRightRadius: 12 },
+  lastDay: {
+    borderBottomLeftRadius: 12,
+    borderBottomRightRadius: 12,
+    marginBottom: 8,
+  },
+  dateChip: {
+    alignSelf: 'flex-start',
+    backgroundColor: '#c0c0c0',
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 20,
     marginBottom: 6,
   },
-  mealItem: {
-    marginBottom: 4,
+  dateText: { fontWeight: '600' },
+  mealItem: { marginBottom: 8 },
+  mealHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 2,
   },
-  mealTitle: {
-    fontWeight: '600',
-  },
-  mealItems: {
-    color: '#555',
-  },
+  mealActions: { flexDirection: 'row' },
+  iconButton: { marginLeft: 8 },
+  mealTitle: { fontWeight: '600' },
+  mealItems: { color: '#555' },
+  pastDay: { opacity: 0.5 },
 });


### PR DESCRIPTION
## Summary
- redesign MonthlyMenuScreen to use safe area and colored backgrounds
- add heart and plus icons for each meal
- highlight past days and scroll to the current day automatically

## Testing
- `npm test` *(fails: missing script)*
- `npx tsc -p tsconfig.json` *(fails: type errors)*

------
https://chatgpt.com/codex/tasks/task_e_684998b84d84832fba73eb237cde24ba