### PR TITLE
Fix syntax errors in MonthlyMenuScreen

### DIFF
--- a/src/screens/MonthlyMenuScreen.tsx
+++ b/src/screens/MonthlyMenuScreen.tsx
@@ -81,17 +81,6 @@ export default function MonthlyMenuScreen() {
             viewPosition: 0,
           });
         }
- 
-      const sectionIndex = Math.floor(idx / 7);
-      const itemIndex = idx % 7;
-      setTimeout(() => {
-        listRef.current?.scrollToLocation({
-          sectionIndex,
-          itemIndex,
-          animated: false,
-          viewPosition: 0,
-        });
- 
       }, 0);
     }
   }, [loading, menu]);
@@ -172,7 +161,7 @@ export default function MonthlyMenuScreen() {
               <Text style={styles.mealItems}>{m.items.join(', ')}</Text>
             </View>
           );
-        })}
+        })
       </View>
     );
   };


### PR DESCRIPTION
## Summary
- clean up duplicated scroll logic
- fix bracket in meals map callback

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68499ba5204c832fa6bda489f83352ad