### PR TITLE
Fix unmatched JSX brace

### DIFF
--- a/src/screens/MonthlyMenuScreen.tsx
+++ b/src/screens/MonthlyMenuScreen.tsx
@@ -161,7 +161,7 @@ export default function MonthlyMenuScreen() {
               <Text style={styles.mealItems}>{m.items.join(', ')}</Text>
             </View>
           );
-        })
+        })}
       </View>
     );
   };


### PR DESCRIPTION
## Summary
- close the `meals.map` JSX block properly in `MonthlyMenuScreen`

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc src/screens/MonthlyMenuScreen.tsx --noEmit` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68499c7ae0a4832f8482295af65756f2