### PR TITLE
Enhance monthly menu styling

### DIFF
--- a/src/screens/MonthlyMenuScreen.tsx
+++ b/src/screens/MonthlyMenuScreen.tsx
@@ -1,5 +1,14 @@
-import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet, SectionList, ActivityIndicator, FlatList } from 'react-native';
+import React, { useEffect, useState, useRef } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  SectionList,
+  ActivityIndicator,
+  Pressable,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import Ionicons from '@expo/vector-icons/Ionicons';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { Meal } from '../data/meals';
 
@@ -10,12 +19,20 @@ import localMenu from '../../monthly-menu-may-2025.json';
 
 const MENU_URL = 'https://raw.githubusercontent.com/a-d-iii/app/main/monthly-menu-may-2025.json';
 
+const WEEK_COLORS = ['#f0e4d7', '#e7f0d7', '#d7e8f0', '#f0d7e8'];
+const DAY_COLORS = ['#e5d7cb', '#dce5cb', '#cbdce5', '#e5cbdc'];
+
 
 interface MonthlyMenu {
   [date: string]: Meal[];
 }
 
-type WeekSection = { title: string; data: { date: string; meals: Meal[] }[] };
+type WeekSection = {
+  title: string;
+  color: string;
+  dayColor: string;
+  data: { date: string; meals: Meal[] }[];
+};
 
 export default function MonthlyMenuScreen() {
 
@@ -24,6 +41,9 @@ export default function MonthlyMenuScreen() {
 
 
   const [loading, setLoading] = useState(true);
+  const [likes, setLikes] = useState<Record<string, boolean>>({});
+  const listRef = useRef<SectionList<any>>(null);
+  const scrollTarget = useRef<{ sectionIndex: number; itemIndex: number }>();
 
   useEffect(() => {
     const loadMenu = async () => {
@@ -47,33 +67,111 @@ export default function MonthlyMenuScreen() {
     loadMenu();
   }, []);
 
-  const toWeeks = (): WeekSection[] => {
+  // Scroll to current day once data is loaded
+  useEffect(() => {
+    if (loading) return;
+    const todayKey = new Date().toISOString().slice(0, 10);
+    const dates = Object.keys(menu).sort();
+    const idx = dates.indexOf(todayKey);
+    if (idx >= 0) {
+      scrollTarget.current = {
+        sectionIndex: Math.floor(idx / 7),
+        itemIndex: idx % 7,
+      };
+      setTimeout(() => {
+        if (scrollTarget.current) {
+          listRef.current?.scrollToLocation({
+            ...scrollTarget.current,
+            animated: false,
+            viewPosition: 0,
+          });
+        }
+      }, 0);
+    }
+  }, [loading, menu]);
 
+  const handleScrollToIndexFailed = () => {
+    if (!scrollTarget.current) return;
+    setTimeout(() => {
+      listRef.current?.scrollToLocation({
+        ...scrollTarget.current!,
+        animated: false,
+        viewPosition: 0,
+      });
+    }, 50);
+  };
+
+  const toWeeks = (): WeekSection[] => {
     if (!menu) return [];
 
     const dates = Object.keys(menu).sort();
     const weeks: WeekSection[] = [];
     for (let i = 0; i < dates.length; i += 7) {
       const slice = dates.slice(i, i + 7);
+      const index = weeks.length;
       weeks.push({
-        title: `Week ${weeks.length + 1}`,
-        data: slice.map(d => ({ date: d, meals: menu[d] }))
+        title: `Week ${index + 1}`,
+        color: WEEK_COLORS[index % WEEK_COLORS.length],
+        dayColor: DAY_COLORS[index % DAY_COLORS.length],
+        data: slice.map((d) => ({ date: d, meals: menu[d] })),
       });
     }
     return weeks;
   };
 
-  const renderDay = ({ date, meals }: { date: string; meals: Meal[] }) => (
-    <View style={styles.dayBlock}>
-      <Text style={styles.dayHeader}>{date}</Text>
-      {meals.map(m => (
-        <View key={`${date}-${m.name}`} style={styles.mealItem}>
-          <Text style={styles.mealTitle}>{m.name}</Text>
-          <Text style={styles.mealItems}>{m.items.join(', ')}</Text>
+  const today = new Date().toISOString().slice(0, 10);
+
+  const toggleLike = (key: string) =>
+    setLikes((prev) => ({ ...prev, [key]: !prev[key] }));
+
+  const renderDay = (
+    { date, meals }: { date: string; meals: Meal[] },
+    index: number,
+    section: WeekSection
+  ) => {
+    const isPast = date < today;
+    return (
+      <View
+        style={[
+          styles.dayBlock,
+          { backgroundColor: section.dayColor },
+          isPast && styles.pastDay,
+          index === 0 && styles.firstDay,
+          index === section.data.length - 1 && styles.lastDay,
+        ]}
+      >
+        <View style={styles.dateChip}>
+          <Text style={styles.dateText}>{date}</Text>
         </View>
-      ))}
-    </View>
-  );
+        {meals.map((m) => {
+          const key = `${date}-${m.name}`;
+          return (
+            <View key={key} style={styles.mealItem}>
+              <View style={styles.mealHeader}>
+                <Text style={styles.mealTitle}>{m.name}</Text>
+                <View style={styles.mealActions}>
+                  <Pressable
+                    onPress={() => toggleLike(key)}
+                    style={styles.iconButton}
+                  >
+                    <Ionicons
+                      name={likes[key] ? 'heart' : 'heart-outline'}
+                      size={16}
+                      color={likes[key] ? 'red' : '#333'}
+                    />
+                  </Pressable>
+                  <Pressable style={styles.iconButton}>
+                    <Ionicons name="add" size={16} color="#333" />
+                  </Pressable>
+                </View>
+              </View>
+              <Text style={styles.mealItems}>{m.items.join(', ')}</Text>
+            </View>
+          );
+        })}
+      </View>
+    );
+  };
 
   if (loading) {
     return (
@@ -84,42 +182,84 @@ export default function MonthlyMenuScreen() {
   }
 
   return (
-    <SectionList
-      sections={toWeeks()}
-      keyExtractor={(item) => item.date}
-      renderItem={({ item }) => renderDay(item)}
-      renderSectionHeader={({ section: { title } }) => (
-        <Text style={styles.sectionHeader}>{title}</Text>
-      )}
-    />
+    <SafeAreaView style={styles.safe}>
+      <SectionList
+        ref={listRef}
+        sections={toWeeks()}
+        keyExtractor={(item) => item.date}
+        renderItem={({ item, index, section }) =>
+          renderDay(item, index, section as WeekSection)
+        }
+        renderSectionHeader={({ section }) => (
+          <View style={[styles.weekHeaderContainer, { backgroundColor: section.dayColor }] }>
+            <View style={styles.weekLabel}>
+              <Text style={styles.sectionHeader}>{section.title}</Text>
+            </View>
+          </View>
+        )}
+        onScrollToIndexFailed={handleScrollToIndexFailed}
+        SectionSeparatorComponent={() => <View style={{ height: 12 }} />}
+        stickySectionHeadersEnabled={false}
+        contentContainerStyle={styles.listContent}
+      />
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: '#f2f2f2' },
   centered: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  listContent: { padding: 12 },
+  weekHeaderContainer: {
+    marginHorizontal: 4,
+    marginBottom: 4,
+    padding: 8,
+    borderTopLeftRadius: 12,
+    borderTopRightRadius: 12,
+    alignItems: 'center',
+  },
+  weekLabel: {
+    backgroundColor: '#000',
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+    borderRadius: 20,
+  },
   sectionHeader: {
-    paddingVertical: 8,
-    paddingHorizontal: 16,
-    backgroundColor: '#eee',
     fontWeight: '600',
+    fontSize: 20,
+    color: '#fff',
   },
   dayBlock: {
-    padding: 16,
+    padding: 12,
+    marginHorizontal: 4,
     borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: '#ccc',
+    borderBottomColor: '#bbb',
   },
-  dayHeader: {
-    fontSize: 16,
-    fontWeight: '600',
+  firstDay: { borderTopLeftRadius: 12, borderTopRightRadius: 12, marginTop: 4 },
+  lastDay: {
+    borderBottomLeftRadius: 12,
+    borderBottomRightRadius: 12,
+    marginBottom: 8,
+  },
+  dateChip: {
+    alignSelf: 'flex-start',
+    backgroundColor: '#c0c0c0',
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 20,
     marginBottom: 6,
   },
-  mealItem: {
-    marginBottom: 4,
+  dateText: { fontWeight: '600' },
+  mealItem: { marginBottom: 8 },
+  mealHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 2,
   },
-  mealTitle: {
-    fontWeight: '600',
-  },
-  mealItems: {
-    color: '#555',
-  },
+  mealActions: { flexDirection: 'row' },
+  iconButton: { marginLeft: 8 },
+  mealTitle: { fontWeight: '600' },
+  mealItems: { color: '#555' },
+  pastDay: { opacity: 0.5 },
 });


### PR DESCRIPTION
## Summary
- refine MonthlyMenuScreen styling with colored weeks
- darken week headings and enlarge text
- apply subtle page background and spacing tweaks
- keep past-day dimming and auto-scroll features

## Testing
- `npm test` *(fails: missing script)*
- `npx tsc -p tsconfig.json` *(fails: type errors)*

------
https://chatgpt.com/codex/tasks/task_e_684998b84d84832fba73eb237cde24ba