### PR TITLE
Fix menu loading by timing out fetch

### DIFF
--- a/src/screens/FoodMenuScreen.tsx
+++ b/src/screens/FoodMenuScreen.tsx
@@ -20,6 +20,7 @@ import RatingModal from '../components/RatingModal';
 // Load the bundled menu as an offline fallback so the screen always has data
 // even when network requests fail.
 import localMenu from '../../monthly-menu-may-2025.json';
+import fetchWithTimeout from '../utils/fetchWithTimeout';
 
 const MENU_URL =
   'https://raw.githubusercontent.com/a-d-iii/app/main/monthly-menu-may-2025.json';
@@ -84,7 +85,7 @@ export default function FoodMenuScreen() {
         if (cached) {
           setMenu(JSON.parse(cached));
         }
-        const resp = await fetch(MENU_URL);
+        const resp = await fetchWithTimeout(MENU_URL, {}, 5000);
         if (resp.ok) {
           const json = await resp.json();
           setMenu(json);

--- a/src/screens/MonthlyMenuScreen.tsx
+++ b/src/screens/MonthlyMenuScreen.tsx
@@ -14,6 +14,7 @@ import type { Meal } from '../data/meals';
 
 // Fallback data bundled with the app for offline use
 import localMenu from '../../monthly-menu-may-2025.json';
+import fetchWithTimeout from '../utils/fetchWithTimeout';
 
 
 
@@ -52,7 +53,7 @@ export default function MonthlyMenuScreen() {
         if (cached) {
           setMenu(JSON.parse(cached));
         }
-        const resp = await fetch(MENU_URL);
+        const resp = await fetchWithTimeout(MENU_URL, {}, 5000);
         if (resp.ok) {
           const json = await resp.json();
           setMenu(json);

--- a/src/utils/fetchWithTimeout.ts
+++ b/src/utils/fetchWithTimeout.ts
@@ -1,0 +1,14 @@
+export default async function fetchWithTimeout(
+  url: string,
+  options: RequestInit = {},
+  timeoutMs = 8000
+): Promise<Response> {
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(id);
+  }
+}
+


### PR DESCRIPTION
## Summary
- handle network stalls when loading menu data
- add `fetchWithTimeout` utility
- use timeout in FoodMenuScreen and MonthlyMenuScreen

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6849aec699a0832fbee48ce2c531b25d