### PR TITLE
Add weekly timetable to planner screen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -16,23 +16,10 @@ import Home from './src/screens/Home';
 import FoodMenuScreen from './src/screens/FoodMenuScreen';
 import MonthlyMenuScreen from './src/screens/MonthlyMenuScreen';
 import FoodSummaryScreen from './src/screens/FoodSummaryScreen';
+import PlannerScreen from './src/screens/Planner';
 
-// Placeholders or existing components for other tabs:
-function PlannerScreen() {
-  return (
-    <View style={styles.placeholder}>
-      <Text style={styles.placeholderText}>Planner Screen</Text>
-    </View>
-  );
-}
-
-function SocialScreen() {
-  return (
-    <View style={styles.placeholder}>
-      <Text style={styles.placeholderText}>Social Screen</Text>
-    </View>
-  );
-}
+// Placeholder or existing component for the Social tab
+import SocialScreen from './src/screens/Social';
 
 // ——— New files you need to create under src/screens: ———
 // src/screens/MoreRootScreen.tsx  (listing utilities, including “Gallery”)

--- a/src/data/weeklySchedule.ts
+++ b/src/data/weeklySchedule.ts
@@ -1,0 +1,50 @@
+export type ClassEntry = {
+  course: string;
+  faculty: string;
+  start: string;
+  end: string;
+  room: string;
+};
+
+export type WeeklySchedule = {
+  [day: string]: ClassEntry[];
+};
+
+export const WEEKLY_SCHEDULE: WeeklySchedule = {
+  Monday: [
+    { course: 'CSE1001', faculty: 'Prof. Rao', start: '08:00', end: '08:50', room: '101' },
+    { course: 'MAT1002', faculty: 'Dr. Singh', start: '09:00', end: '09:50', room: '201' },
+    { course: 'PHY1003', faculty: 'Dr. Patel', start: '10:00', end: '10:50', room: 'Lab 1' },
+    { course: 'ENG1004', faculty: 'Ms. James', start: '11:00', end: '11:50', room: '305' },
+  ],
+  Tuesday: [
+    { course: 'CHE1005', faculty: 'Dr. Verma', start: '08:00', end: '08:50', room: '202' },
+    { course: 'CSE1001', faculty: 'Prof. Rao', start: '09:00', end: '09:50', room: '101' },
+    { course: 'MAT1002', faculty: 'Dr. Singh', start: '10:00', end: '10:50', room: '201' },
+    { course: 'PHY1003', faculty: 'Dr. Patel', start: '11:00', end: '11:50', room: 'Lab 1' },
+  ],
+  Wednesday: [
+    { course: 'ENG1004', faculty: 'Ms. James', start: '08:00', end: '08:50', room: '305' },
+    { course: 'CSE1001', faculty: 'Prof. Rao', start: '09:00', end: '09:50', room: '101' },
+    { course: 'CHE1005', faculty: 'Dr. Verma', start: '10:00', end: '10:50', room: '202' },
+    { course: 'MAT1002', faculty: 'Dr. Singh', start: '11:00', end: '11:50', room: '201' },
+  ],
+  Thursday: [
+    { course: 'PHY1003', faculty: 'Dr. Patel', start: '08:00', end: '08:50', room: 'Lab 1' },
+    { course: 'ENG1004', faculty: 'Ms. James', start: '09:00', end: '09:50', room: '305' },
+    { course: 'CSE1001', faculty: 'Prof. Rao', start: '10:00', end: '10:50', room: '101' },
+    { course: 'CHE1005', faculty: 'Dr. Verma', start: '11:00', end: '11:50', room: '202' },
+  ],
+  Friday: [
+    { course: 'MAT1002', faculty: 'Dr. Singh', start: '08:00', end: '08:50', room: '201' },
+    { course: 'PHY1003', faculty: 'Dr. Patel', start: '09:00', end: '09:50', room: 'Lab 1' },
+    { course: 'ENG1004', faculty: 'Ms. James', start: '10:00', end: '10:50', room: '305' },
+    { course: 'CHE1005', faculty: 'Dr. Verma', start: '11:00', end: '11:50', room: '202' },
+  ],
+  Saturday: [
+    { course: 'CSE1001', faculty: 'Prof. Rao', start: '09:00', end: '10:30', room: '101' },
+    { course: 'LAB Project', faculty: 'Staff', start: '10:45', end: '12:15', room: 'Innovation Lab' },
+  ],
+};
+
+export default WEEKLY_SCHEDULE;

--- a/src/screens/Planner.tsx
+++ b/src/screens/Planner.tsx
@@ -1,18 +1,114 @@
-// src/screens/Planner.tsx
+import React, { useState } from 'react';
+import {
+  SafeAreaView,
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  Platform,
+  StatusBar,
+} from 'react-native';
+import { WEEKLY_SCHEDULE, ClassEntry } from '../data/weeklySchedule';
 
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+const DAYS = Object.keys(WEEKLY_SCHEDULE);
 
 export default function Planner() {
+  const [day, setDay] = useState<string>(DAYS[0]);
+  const classes: ClassEntry[] = WEEKLY_SCHEDULE[day];
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.heading}>Planner</Text>
-      {/* Add your planner UI here */}
-    </View>
+    <SafeAreaView
+      style={[
+        styles.container,
+        { paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 },
+      ]}
+    >
+      <Text style={styles.heading}>Weekly Timetable</Text>
+
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        style={styles.dayRow}
+        contentContainerStyle={{ paddingHorizontal: 16 }}
+      >
+        {DAYS.map((d) => (
+          <TouchableOpacity
+            key={d}
+            onPress={() => setDay(d)}
+            style={[styles.dayButton, day === d && styles.dayButtonActive]}
+          >
+            <Text
+              style={[styles.dayText, day === d && styles.dayTextActive]}
+            >
+              {d.slice(0, 3)}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </ScrollView>
+
+      <ScrollView contentContainerStyle={styles.scheduleContainer}>
+        {classes.map((cls, idx) => (
+          <View key={idx} style={styles.classBox}>
+            <View style={styles.classLeft}>
+              <Text style={styles.courseText}>{cls.course}</Text>
+              <Text style={styles.facultyText}>{cls.faculty}</Text>
+            </View>
+            <View style={styles.classRight}>
+              <Text style={styles.timeText}>
+                {cls.start} – {cls.end}
+              </Text>
+              <Text style={styles.roomText}>{cls.room}</Text>
+            </View>
+          </View>
+        ))}
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
-  heading: { fontSize: 24, fontWeight: '700', color: '#333' },
+  container: { flex: 1, backgroundColor: '#f0f2f5' },
+  heading: {
+    fontSize: 22,
+    fontWeight: '700',
+    marginVertical: 16,
+    marginHorizontal: 16,
+    color: '#333',
+  },
+  dayRow: {
+    flexGrow: 0,
+  },
+  dayButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 20,
+    marginRight: 8,
+    backgroundColor: '#e0e0e0',
+  },
+  dayButtonActive: {
+    backgroundColor: '#6C5CE7',
+  },
+  dayText: { fontSize: 14, color: '#333' },
+  dayTextActive: { color: '#fff', fontWeight: '700' },
+  scheduleContainer: { padding: 16 },
+  classBox: {
+    flexDirection: 'row',
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    marginVertical: 6,
+    elevation: 1,
+    shadowColor: '#000',
+    shadowOpacity: 0.05,
+    shadowOffset: { width: 0, height: 0.5 },
+    shadowRadius: 2,
+  },
+  classLeft: { flex: 1 },
+  courseText: { fontSize: 14, fontWeight: '600', color: '#333' },
+  facultyText: { fontSize: 12, color: '#666', marginTop: 2 },
+  classRight: { justifyContent: 'space-between', alignItems: 'flex-end' },
+  timeText: { fontSize: 12, color: '#333' },
+  roomText: { fontSize: 10, color: '#666', marginTop: 2 },
 });


### PR DESCRIPTION
## Summary
- integrate real Planner screen in navigation
- implement day-wise weekly timetable UI
- provide sample schedule data

## Testing
- `npx tsc --noEmit` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*

------
https://chatgpt.com/codex/tasks/task_e_6849b53e922c832fb5f8aec7a78f561a