### PR TITLE
Fix Attendance screen export error

### DIFF
--- a/src/screens/Attendance.tsx
+++ b/src/screens/Attendance.tsx
@@ -58,16 +58,11 @@ function SubjectCard({ item }: { item: typeof subjects[0] }) {
       ]),
     ).start();
   }, [scale]);
- 
 
-function SubjectCard({ item }: { item: typeof subjects[0] }) {
-  const bg = getBackgroundColor(item.attendance);
-  const icon = getIcon(item.attendance);
   return (
     <View style={[styles.card, { backgroundColor: bg }]}>
       <View style={styles.header}>
         <Text style={styles.subject}>{item.name}</Text>
- 
       </View>
       <View style={styles.body}>
         <View style={styles.percentWrap}>
@@ -78,7 +73,6 @@ function SubjectCard({ item }: { item: typeof subjects[0] }) {
           <Ionicons name={icon as any} size={22} color="#333" style={styles.icon} />
         </Animated.View>
       </View>
- 
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- fix unbalanced function definition in `Attendance` screen

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module '@expo/vector-icons/Ionicons' or its corresponding type declarations, etc.)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_685aa1719658832fb84179275eb94dec