### PR TITLE
Add troubleshooting note for missing NDK files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,12 @@
    ```
 
 Make sure you have the Expo CLI installed and Android SDK configured.
+
+## Troubleshooting
+
+### NDK missing `source.properties`
+If the Android build fails with:
+```
+[CXX1101] NDK at <path> did not have a source.properties file
+```
+reinstall the specified NDK using `sdkmanager` or Android Studio and verify that the folder contains a `source.properties` file.


### PR DESCRIPTION
## Summary
- document fix for missing `source.properties` error when running the Android build

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685addda0b90832fbfcaf72c9afa6db0